### PR TITLE
feat(config): zod-validated secrets and agentry config schema (#27)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# agentry secrets — copy to .env and fill in.
+#
+# Loading: with Node 22+ run `node --env-file=.env apps/server/dist/main.js`.
+# In Docker Compose, point `env_file:` at this file. Never commit .env.
+# `.env` is gitignored; `.env.example` is committed and documents what keys
+# the runtime expects. SecretsSchema (packages/runtime/src/config/secrets.ts)
+# is the source of truth — keep this file in sync.
+
+# --- Slack -------------------------------------------------------------------
+# Bot token issued by Slack (must start with "xoxb-").
+SLACK_BOT_TOKEN=xoxb-replace-me
+# Used to verify Slack request signatures. Find under "Basic Information".
+SLACK_SIGNING_SECRET=replace-me
+
+# --- Postgres ----------------------------------------------------------------
+# Single connection string. Includes user, password, host, port, database.
+POSTGRES_URL=postgres://agentry:agentry@localhost:5432/agentry
+
+# --- Embeddings --------------------------------------------------------------
+# Voyage API key — default embedding provider (model: voyage-3).
+VOYAGE_API_KEY=pa-replace-me

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -613,7 +613,7 @@ secrets into git or scatters configuration.
 
 | Tier | Examples | Storage |
 |---|---|---|
-| **Secret** (never in git) | `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `VOYAGE_API_KEY`, `POSTGRES_PASSWORD` | Env vars only. `.env` (gitignored) → `docker-compose env_file` → `process.env`. `zod`-validated at startup; missing values cause immediate fail. |
+| **Secret** (never in git) | `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `VOYAGE_API_KEY`, `POSTGRES_URL` | Env vars only. `.env` (gitignored) → `docker-compose env_file` → `process.env`. `zod`-validated at startup; missing values cause immediate fail. |
 | **Configuration** (workspace/deployment-specific) | Channel allowlists, idle timeout, embedding model name, distillation triggers | `agentry.config.ts` (TypeScript, committable). Values come from env interpolation: `channels: process.env.SLACK_ALLOWED_CHANNELS?.split(',')`. |
 | **Runtime-resolved** (dynamic) | Slack channel IDs from `#channel-name` mentions, user info, message timestamps | Not pre-configured. Agent resolves via tools (§11) at run time. |
 

--- a/docs/extending/configuration.md
+++ b/docs/extending/configuration.md
@@ -1,0 +1,113 @@
+# Configuration
+
+agentry separates runtime values into three tiers (per ARCHITECTURE.md §10).
+Each value belongs to exactly one tier — mixing them either leaks secrets into
+git or scatters configuration across runtime sources.
+
+| Tier | Examples | Where it lives |
+|---|---|---|
+| **Secret** (never in git) | `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `POSTGRES_URL`, `VOYAGE_API_KEY` | Process env. Validated by `SecretsSchema` (zod) at startup. |
+| **Configuration** (per-deployment) | Channel allowlists, idle timeouts, embedding model, distillation triggers | `agentry.config.ts` (TypeScript, committed to the fork). Values may interpolate from env. |
+| **Runtime-resolved** (dynamic) | Slack channel IDs, user info, message timestamps | Not pre-configured. The agent resolves them via tools at run time (see ARCHITECTURE.md §11). |
+
+## Secrets
+
+`packages/runtime/src/config/secrets.ts` exports `SecretsSchema`, the
+`Secrets` type, and `loadSecrets(env?)`. The composition root calls
+`loadSecrets()` once at startup; missing or malformed values raise a
+`SecretsValidationError` whose message lists every offending key with the
+rule that was violated. Secret values themselves are never echoed back —
+operators see the key name and the rule, not the bad input.
+
+```ts
+import { loadSecrets } from '@agentry/runtime';
+
+const secrets = loadSecrets(); // reads process.env by default
+```
+
+### Loading env vars
+
+Use Node 22+'s built-in flag — no `dotenv` dependency required:
+
+```bash
+node --env-file=.env apps/server/dist/main.js
+```
+
+In Docker Compose, point `env_file:` at the same `.env`. Both are documented
+in `.env.example` at the repo root.
+
+### Swapping the secrets source
+
+`loadSecrets(env?)` accepts any `NodeJS.ProcessEnv`-shaped object. To pull
+from a secret manager (Vault, AWS Secrets Manager, Doppler, …), populate an
+in-memory record and pass it in:
+
+```ts
+import { loadSecrets } from '@agentry/runtime';
+import { fetchVaultSecrets } from './my-vault-loader.js';
+
+const env = await fetchVaultSecrets();
+const secrets = loadSecrets(env);
+```
+
+Adapters consume `secrets` through normal property access — they don't know
+or care where the values originated.
+
+### Adapter-specific secrets *(open question)*
+
+The current `SecretsSchema` is centralized in `packages/runtime`. As more
+adapters land, each will want its own keys (e.g., a Discord adapter adding
+`DISCORD_BOT_TOKEN`). The extension contract is not yet decided:
+
+- **Option A** — extend the central schema in `runtime` for every adapter.
+  Simple, but `runtime` accretes adapter-specific fields.
+- **Option B** — each adapter exports its own `loadXxxSecrets()`.
+  Keeps boundaries clean, but the composition root juggles N loaders.
+- **Option C** — adapters export schema fragments; `runtime` provides a
+  builder that merges them at composition time.
+
+This will be settled when the second adapter (issue #18, Slack) lands.
+Until then, treat `SecretsSchema` as the single source of truth.
+
+## Configuration (`agentry.config.ts`)
+
+Forks define an `agentry.config.ts` at the repo root and import it from
+their server entry point. Use `defineConfig` for type inference plus zod
+validation:
+
+```ts
+import { defineConfig } from '@agentry/runtime';
+
+export default defineConfig({
+  agentWorkdir: process.env.AGENT_WORKDIR ?? './seed/agent-workdir',
+  logging: { level: 'info' },
+});
+```
+
+`defineConfig` is an identity function with a runtime parse — no file system
+loading, no `tsx` magic. Importers compose the result into the runtime
+manually (see `compose.ts`, issue #12).
+
+### Env interpolation
+
+There is no special interpolation syntax. The config file is plain
+TypeScript, so `process.env.FOO` works directly:
+
+```ts
+defineConfig({
+  agentWorkdir: process.env.AGENT_WORKDIR ?? './seed/agent-workdir',
+});
+```
+
+Group secret-derived values with their consumer (typically an adapter),
+not in the global config object.
+
+## Where each value belongs
+
+Before adding a new value, decide its tier by asking:
+
+1. **Would committing this to git be a security incident?** → Secret.
+2. **Does this differ between forks/deployments but not between sessions?**
+   → Configuration.
+3. **Does this depend on something the user just said?**
+   → Runtime-resolved (a tool, not config).

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,6 +16,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agentry/core": "workspace:*"
+    "@agentry/core": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.2"
   }
 }

--- a/packages/runtime/src/config/agentry-config.test.ts
+++ b/packages/runtime/src/config/agentry-config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { defineConfig } from './agentry-config.js';
+
+describe('defineConfig', () => {
+  it('applies default logging when omitted', () => {
+    const config = defineConfig({ agentWorkdir: '/tmp/agent' });
+    expect(config.logging.level).toBe('info');
+  });
+
+  it('applies default level when logging is given without level', () => {
+    const config = defineConfig({ agentWorkdir: '/tmp/agent', logging: {} });
+    expect(config.logging.level).toBe('info');
+  });
+
+  it('preserves explicit logging level', () => {
+    const config = defineConfig({
+      agentWorkdir: '/tmp/agent',
+      logging: { level: 'debug' },
+    });
+    expect(config.logging.level).toBe('debug');
+  });
+
+  it('rejects empty agentWorkdir', () => {
+    expect(() => defineConfig({ agentWorkdir: '' })).toThrow();
+  });
+
+  it('rejects unknown log level', () => {
+    expect(() =>
+      defineConfig({
+        agentWorkdir: '/tmp/agent',
+        // @ts-expect-error — testing runtime validation of invalid input
+        logging: { level: 'verbose' },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/runtime/src/config/agentry-config.ts
+++ b/packages/runtime/src/config/agentry-config.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const LogLevelSchema = z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']);
+
+export const AgentryConfigSchema = z.object({
+  agentWorkdir: z.string().min(1, 'agentWorkdir must not be empty'),
+  logging: z
+    .object({
+      level: LogLevelSchema.default('info'),
+    })
+    .default({ level: 'info' }),
+});
+
+export type AgentryConfigInput = z.input<typeof AgentryConfigSchema>;
+export type AgentryConfig = z.output<typeof AgentryConfigSchema>;
+
+export function defineConfig(config: AgentryConfigInput): AgentryConfig {
+  return AgentryConfigSchema.parse(config);
+}

--- a/packages/runtime/src/config/index.ts
+++ b/packages/runtime/src/config/index.ts
@@ -1,0 +1,13 @@
+export {
+  type AgentryConfig,
+  type AgentryConfigInput,
+  AgentryConfigSchema,
+  defineConfig,
+} from './agentry-config.js';
+export {
+  loadSecrets,
+  type Secrets,
+  type SecretsIssue,
+  SecretsSchema,
+  SecretsValidationError,
+} from './secrets.js';

--- a/packages/runtime/src/config/secrets.test.ts
+++ b/packages/runtime/src/config/secrets.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { loadSecrets, SecretsValidationError } from './secrets.js';
+
+const validEnv = {
+  SLACK_BOT_TOKEN: 'xoxb-1234567890-abcdefg',
+  SLACK_SIGNING_SECRET: '0123456789abcdef0123456789abcdef',
+  POSTGRES_URL: 'postgres://user:pass@localhost:5432/agentry',
+  VOYAGE_API_KEY: 'pa-test-key',
+};
+
+describe('loadSecrets', () => {
+  it('returns parsed Secrets when env is valid', () => {
+    const secrets = loadSecrets(validEnv);
+    expect(secrets.SLACK_BOT_TOKEN).toBe(validEnv.SLACK_BOT_TOKEN);
+    expect(secrets.POSTGRES_URL).toBe(validEnv.POSTGRES_URL);
+  });
+
+  it('ignores extra env keys not declared in the schema', () => {
+    const secrets = loadSecrets({ ...validEnv, UNRELATED_KEY: 'something' });
+    expect(secrets).not.toHaveProperty('UNRELATED_KEY');
+  });
+
+  it('throws SecretsValidationError listing every missing key', () => {
+    let caught: unknown;
+    try {
+      loadSecrets({});
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SecretsValidationError);
+    const err = caught as SecretsValidationError;
+    const keys = err.issues.map((i) => i.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        'SLACK_BOT_TOKEN',
+        'SLACK_SIGNING_SECRET',
+        'POSTGRES_URL',
+        'VOYAGE_API_KEY',
+      ]),
+    );
+  });
+
+  it('reports an actionable rule message for invalid prefix', () => {
+    let caught: unknown;
+    try {
+      loadSecrets({ ...validEnv, SLACK_BOT_TOKEN: 'wrong-prefix-token' });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(SecretsValidationError);
+    const err = caught as SecretsValidationError;
+    const slackIssue = err.issues.find((i) => i.key === 'SLACK_BOT_TOKEN');
+    expect(slackIssue?.message).toMatch(/xoxb-/);
+  });
+
+  it('rejects malformed POSTGRES_URL', () => {
+    expect(() => loadSecrets({ ...validEnv, POSTGRES_URL: 'not-a-url' })).toThrow(
+      SecretsValidationError,
+    );
+  });
+
+  it('does NOT echo the offending secret value in the error message', () => {
+    const sentinel = 'xoxb-leaked-token-do-not-log-12345';
+    let caught: SecretsValidationError | undefined;
+    try {
+      loadSecrets({
+        ...validEnv,
+        SLACK_BOT_TOKEN: 'wrong',
+        VOYAGE_API_KEY: sentinel,
+        POSTGRES_URL: 'http://leaked.example/?secret=tail-leak-9876',
+      });
+    } catch (error) {
+      caught = error as SecretsValidationError;
+    }
+    expect(caught).toBeInstanceOf(SecretsValidationError);
+    const message = caught?.message ?? '';
+    expect(message).not.toContain(sentinel);
+    expect(message).not.toContain('tail-leak-9876');
+    expect(message).not.toContain('wrong');
+    for (const issue of caught?.issues ?? []) {
+      expect(issue.message).not.toContain(sentinel);
+      expect(issue.message).not.toContain('tail-leak-9876');
+    }
+  });
+});

--- a/packages/runtime/src/config/secrets.ts
+++ b/packages/runtime/src/config/secrets.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+
+export const SecretsSchema = z.object({
+  SLACK_BOT_TOKEN: z.string().startsWith('xoxb-', 'must start with "xoxb-"'),
+  SLACK_SIGNING_SECRET: z.string().min(1, 'must not be empty'),
+  POSTGRES_URL: z.url(),
+  VOYAGE_API_KEY: z.string().min(1, 'must not be empty'),
+});
+
+export type Secrets = z.infer<typeof SecretsSchema>;
+
+export interface SecretsIssue {
+  readonly key: string;
+  readonly message: string;
+}
+
+export class SecretsValidationError extends Error {
+  readonly issues: ReadonlyArray<SecretsIssue>;
+
+  constructor(issues: ReadonlyArray<SecretsIssue>) {
+    const lines = issues.map((i) => `  - ${i.key}: ${i.message}`).join('\n');
+    super(
+      `Invalid or missing environment variables:\n${lines}\n\n` +
+        'See .env.example for required keys. ' +
+        'Set them via shell, an env file (Node 22+: `node --env-file=.env ...`), ' +
+        'or a secret manager loader.',
+    );
+    this.name = 'SecretsValidationError';
+    this.issues = issues;
+  }
+}
+
+export function loadSecrets(env: NodeJS.ProcessEnv = process.env): Secrets {
+  const result = SecretsSchema.safeParse(env);
+  if (result.success) return result.data;
+
+  const issues: SecretsIssue[] = result.error.issues.map((issue) => ({
+    key: issue.path.join('.'),
+    message: issue.message,
+  }));
+  throw new SecretsValidationError(issues);
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,1 +1,3 @@
 export const RUNTIME_VERSION = '0.0.0' as const;
+
+export * from './config/index.js';

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,13 @@ importers:
       '@agentry/core':
         specifier: workspace:*
         version: link:../core
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
 
   packages/testing:
     dependencies:
@@ -896,6 +903,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@biomejs/biome@2.4.13':
@@ -1526,3 +1536,5 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  zod@4.3.6: {}


### PR DESCRIPTION
Closes #27.

## Summary

Implements ARCHITECTURE.md §10 three-tier configuration model (Secret / Configuration / Runtime-resolved):

- **`SecretsSchema`** (zod) + **`loadSecrets(env?)`** in `packages/runtime/src/config/secrets.ts`. Throws `SecretsValidationError` on missing/invalid env, with an actionable message that lists every offending key + rule. Secret values are never echoed back — verified by a sentinel-leak test.
- **`AgentryConfigSchema`** + **`defineConfig()`** in `packages/runtime/src/config/agentry-config.ts`. Identity helper that runs the schema parse — fork users `import` their own config and pass it to the composition root (`compose.ts`, deferred to #12).
- **`.env.example`** at the repo root, grouped by category (Slack / Postgres / Embedding) with comments referencing Node 22+ `--env-file=.env`.
- **`docs/extending/configuration.md`** — three-tier explanation, secret-manager swap pattern, and an explicit "open question" section flagging the adapter schema-extension contract as TBD until the second adapter (Slack, #18) lands.
- **ARCHITECTURE.md §10** — fixed `POSTGRES_PASSWORD` → `POSTGRES_URL` to match the implementation.

### Decisions worth flagging

- **zod v4** (`^4.3.6`); v4-style `z.url()` top-level format validator. Inner `+` outer `.default()` on `logging` is required in v4 — output-typed defaults handle the missing-object case, the inner default handles the empty-object case.
- **No `dotenv` dependency.** Node 22+ `--env-file` covers the use case; documented in `.env.example` and `docs/extending/configuration.md`.
- **`loadSecrets()` as a function, not a top-level singleton** — keeps tests isolated, lets adapters or apps swap the env source (e.g., a secret manager).
- **No wiring into `apps/server` / `apps/cli`** — composition root is #12. This PR ships the schema infrastructure only.
- **`tsconfig.json` `types: ["node"]`** added to `packages/runtime` for `NodeJS.ProcessEnv` typing; `@types/node` added as devDependency.

## Verification

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 12/12 pass (6 new in `secrets.test.ts`, 5 new in `agentry-config.test.ts`)
- [x] `pnpm lint` (Biome) clean
- [x] `pnpm depcheck` clean (3 pre-existing `no-orphans` warnings on stub entry files, unchanged)
- [x] Sentinel-leak test asserts secret values do not appear in error output
- [x] `.env` is gitignored (existing rule)
- [x] No stale `POSTGRES_PASSWORD` references anywhere in repo

## Test plan

- [ ] Reviewer sanity-checks `secrets.test.ts` sentinel asserts (verifies the leak guard isn't trivially passing)
- [ ] `pnpm typecheck && pnpm test && pnpm lint` on a clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)