### PR TITLE
feat(adapter): Claude CLI subprocess runner (#19)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -14,9 +14,12 @@ module.exports = {
     {
       name: 'adapters-only-import-core',
       severity: 'error',
-      comment: 'adapter-* may only import from core.',
-      from: { path: '^packages/adapter-' },
-      to: { path: '^(packages/(?!core/)|apps/)' },
+      comment: 'adapter-* may only import from core (or itself).',
+      from: { path: '^packages/(adapter-[^/]+)/' },
+      to: {
+        path: '^(packages/|apps/)',
+        pathNot: '^packages/(core|$1)/',
+      },
     },
     {
       name: 'testing-only-imports-core',

--- a/packages/adapter-runner-claude-cli/package.json
+++ b/packages/adapter-runner-claude-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agentry/core",
+  "name": "@agentry/adapter-runner-claude-cli",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -15,7 +15,10 @@
     "build": "tsc -b",
     "test": "vitest run"
   },
+  "dependencies": {
+    "@agentry/core": "workspace:*"
+  },
   "devDependencies": {
-    "@types/node": "^25.6.0"
+    "@types/node": "^24.12.2"
   }
 }

--- a/packages/adapter-runner-claude-cli/src/__fixtures__/error.ndjson
+++ b/packages/adapter-runner-claude-cli/src/__fixtures__/error.ndjson
@@ -1,0 +1,2 @@
+{"type":"system","subtype":"init","cwd":"/tmp/agent","session_id":"err-session-001","model":"claude-opus-4-7"}
+{"type":"result","subtype":"error","is_error":true,"api_error_status":"overloaded","duration_ms":120,"num_turns":0,"session_id":"err-session-001","total_cost_usd":0,"usage":{"input_tokens":0,"output_tokens":0},"terminal_reason":"api_error"}

--- a/packages/adapter-runner-claude-cli/src/__fixtures__/success-text-only.ndjson
+++ b/packages/adapter-runner-claude-cli/src/__fixtures__/success-text-only.ndjson
@@ -1,0 +1,4 @@
+{"type":"system","subtype":"init","cwd":"/tmp/agent","session_id":"7adc099b-5d70-4b85-b614-bceb95a7b2e7","model":"claude-opus-4-7"}
+{"type":"assistant","message":{"model":"claude-opus-4-7","id":"msg_01BnFSxjZ6aQtxeXvpszJXAT","type":"message","role":"assistant","content":[{"type":"text","text":"4"}],"stop_reason":null,"usage":{"input_tokens":5,"cache_creation_input_tokens":45025,"cache_read_input_tokens":0,"output_tokens":1}},"session_id":"7adc099b-5d70-4b85-b614-bceb95a7b2e7"}
+{"type":"rate_limit_event","rate_limit_info":{"status":"allowed"},"session_id":"7adc099b-5d70-4b85-b614-bceb95a7b2e7"}
+{"type":"result","subtype":"success","is_error":false,"duration_ms":2867,"num_turns":1,"result":"4","stop_reason":"end_turn","session_id":"7adc099b-5d70-4b85-b614-bceb95a7b2e7","total_cost_usd":0.28158125,"usage":{"input_tokens":5,"cache_creation_input_tokens":45025,"cache_read_input_tokens":0,"output_tokens":6},"terminal_reason":"completed"}

--- a/packages/adapter-runner-claude-cli/src/claude-cli-runner.test.ts
+++ b/packages/adapter-runner-claude-cli/src/claude-cli-runner.test.ts
@@ -1,0 +1,180 @@
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import type { AgentEvent } from '@agentry/core';
+import { describe, expect, it } from 'vitest';
+import { ClaudeCliAgentRunner } from './claude-cli-runner.js';
+
+class FakeChildProcess extends EventEmitter {
+  stdin = new PassThrough();
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  exitCode: number | null = null;
+  killSignal?: NodeJS.Signals | number;
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killSignal = signal;
+    return true;
+  }
+
+  pushStdoutLine(json: string): void {
+    this.stdout.write(`${json}\n`);
+  }
+  emitExit(code: number | null): void {
+    this.exitCode = code;
+    this.stdout.end();
+    this.stderr.end();
+    this.emit('exit', code);
+  }
+  emitError(err: Error): void {
+    this.emit('error', err);
+  }
+}
+
+function asChildProcess(fake: FakeChildProcess): ChildProcess {
+  return fake as unknown as ChildProcess;
+}
+
+async function collect<T>(it: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const x of it) result.push(x);
+  return result;
+}
+
+const baseInput = { sessionId: 's', workdir: '/tmp', prompt: 'hi' } as const;
+
+describe('ClaudeCliAgentRunner', () => {
+  it('streams text_delta + finished{complete} for a successful run', async () => {
+    const fake = new FakeChildProcess();
+    const runner = new ClaudeCliAgentRunner({ spawn: () => asChildProcess(fake) });
+    const events = collect(runner.run(baseInput));
+
+    fake.pushStdoutLine('{"type":"system","subtype":"init","session_id":"sid-1"}');
+    fake.pushStdoutLine('{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}');
+    fake.pushStdoutLine(
+      '{"type":"result","subtype":"success","is_error":false,"session_id":"sid-1","usage":{"input_tokens":1,"output_tokens":2}}',
+    );
+    fake.emitExit(0);
+
+    expect(await events).toEqual([
+      { type: 'text_delta', text: 'hi' },
+      {
+        type: 'finished',
+        reason: 'complete',
+        usage: { input: 1, output: 2 },
+        resumeKey: 'sid-1',
+      },
+    ]);
+  });
+
+  it('writes prompt to stdin and ends it', async () => {
+    const fake = new FakeChildProcess();
+    let stdinData = '';
+    fake.stdin.on('data', (chunk: Buffer) => {
+      stdinData += chunk.toString();
+    });
+    const stdinEnded = new Promise<void>((resolve) => fake.stdin.once('end', resolve));
+    const runner = new ClaudeCliAgentRunner({ spawn: () => asChildProcess(fake) });
+    const events = collect(runner.run({ ...baseInput, prompt: 'hello world' }));
+
+    await stdinEnded;
+    fake.pushStdoutLine(
+      '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":0,"output_tokens":0}}',
+    );
+    fake.emitExit(0);
+    await events;
+
+    expect(stdinData).toBe('hello world');
+  });
+
+  it('passes --resume when input.resumeKey is set', async () => {
+    const fake = new FakeChildProcess();
+    let captured: readonly string[] = [];
+    const runner = new ClaudeCliAgentRunner({
+      spawn: (_cmd, args) => {
+        captured = args;
+        return asChildProcess(fake);
+      },
+    });
+    const events = collect(runner.run({ ...baseInput, resumeKey: 'abc-resume' }));
+    fake.pushStdoutLine(
+      '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":0,"output_tokens":0}}',
+    );
+    fake.emitExit(0);
+    await events;
+
+    expect(captured).toContain('--resume');
+    expect(captured).toContain('abc-resume');
+  });
+
+  it('omits --resume when no resumeKey provided', async () => {
+    const fake = new FakeChildProcess();
+    let captured: readonly string[] = [];
+    const runner = new ClaudeCliAgentRunner({
+      spawn: (_cmd, args) => {
+        captured = args;
+        return asChildProcess(fake);
+      },
+    });
+    const events = collect(runner.run(baseInput));
+    fake.pushStdoutLine(
+      '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":0,"output_tokens":0}}',
+    );
+    fake.emitExit(0);
+    await events;
+
+    expect(captured).not.toContain('--resume');
+  });
+
+  it('emits finished{aborted} and signals SIGTERM when AbortSignal fires', async () => {
+    const fake = new FakeChildProcess();
+    const ac = new AbortController();
+    const runner = new ClaudeCliAgentRunner({ spawn: () => asChildProcess(fake) });
+    const eventsPromise = collect(runner.run({ ...baseInput, abortSignal: ac.signal }));
+
+    setImmediate(() => {
+      ac.abort();
+      setImmediate(() => fake.emitExit(null));
+    });
+
+    const events = await eventsPromise;
+    expect(fake.killSignal).toBe('SIGTERM');
+    expect(events.at(-1)).toMatchObject({ type: 'finished', reason: 'aborted' });
+  });
+
+  it('emits error + finished{error} on spawn error event (e.g. ENOENT)', async () => {
+    const fake = new FakeChildProcess();
+    const runner = new ClaudeCliAgentRunner({ spawn: () => asChildProcess(fake) });
+    const eventsPromise = collect(runner.run(baseInput));
+
+    setImmediate(() => {
+      fake.emitError(new Error('spawn claude ENOENT'));
+      fake.emitExit(null);
+    });
+
+    const events = await eventsPromise;
+    expect(events).toEqual([
+      { type: 'error', message: 'spawn claude ENOENT', recoverable: false },
+      { type: 'finished', reason: 'error', usage: { input: 0, output: 0 } },
+    ]);
+  });
+
+  it('emits error + finished{error} when child exits without a result line, including stderr tail', async () => {
+    const fake = new FakeChildProcess();
+    const runner = new ClaudeCliAgentRunner({ spawn: () => asChildProcess(fake) });
+    const eventsPromise = collect(runner.run(baseInput));
+
+    setImmediate(() => {
+      fake.stderr.write('panic: something went wrong\n');
+      fake.emitExit(1);
+    });
+
+    const events = await eventsPromise;
+    expect(events).toHaveLength(2);
+    const errorEv = events[0] as Extract<AgentEvent, { type: 'error' }>;
+    expect(errorEv.type).toBe('error');
+    expect(errorEv.message).toContain('exited with code 1');
+    expect(errorEv.message).toContain('panic');
+    expect(events[1]).toMatchObject({ type: 'finished', reason: 'error' });
+  });
+});

--- a/packages/adapter-runner-claude-cli/src/claude-cli-runner.ts
+++ b/packages/adapter-runner-claude-cli/src/claude-cli-runner.ts
@@ -1,0 +1,125 @@
+import { type ChildProcess, spawn as defaultSpawn, type SpawnOptions } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import type { AgentEvent, AgentRunInput, AgentRunner, TokenUsage } from '@agentry/core';
+import { createParserState, finishedEvent, parseLine } from './stream-parser.js';
+
+export type SpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: SpawnOptions,
+) => ChildProcess;
+
+export interface ClaudeCliAgentRunnerOptions {
+  readonly claudeBinary?: string;
+  readonly spawn?: SpawnFn;
+}
+
+const ZERO_USAGE: TokenUsage = { input: 0, output: 0 };
+
+const BASE_CLI_ARGS = [
+  '-p',
+  '--output-format',
+  'stream-json',
+  '--verbose',
+  '--input-format',
+  'text',
+] as const;
+
+export class ClaudeCliAgentRunner implements AgentRunner {
+  readonly kind = 'claude_cli';
+
+  constructor(private readonly options: ClaudeCliAgentRunnerOptions = {}) {}
+
+  async *run(input: AgentRunInput): AsyncIterable<AgentEvent> {
+    const binary = this.options.claudeBinary ?? 'claude';
+    const spawnFn = this.options.spawn ?? defaultSpawn;
+    const args = buildArgs(input);
+
+    const child = spawnFn(binary, args, {
+      cwd: input.workdir,
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    if (child.stdin === null || child.stdout === null || child.stderr === null) {
+      yield { type: 'error', message: 'subprocess streams unavailable', recoverable: false };
+      yield finishedEvent('error', ZERO_USAGE);
+      return;
+    }
+
+    let spawnError: Error | undefined;
+    child.on('error', (err) => {
+      spawnError = err;
+    });
+
+    const exitPromise = new Promise<number | null>((resolve) => {
+      child.once('exit', resolve);
+    });
+
+    child.stdin.on('error', () => {
+      // Suppress EPIPE when the child exits before consuming stdin.
+    });
+    child.stdin.write(input.prompt);
+    child.stdin.end();
+
+    let aborted = false;
+    const abortSignal = input.abortSignal;
+    const onAbort = () => {
+      aborted = true;
+      child.kill('SIGTERM');
+    };
+    if (abortSignal) {
+      if (abortSignal.aborted) onAbort();
+      else abortSignal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    let stderrTail = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk: string) => {
+      stderrTail = (stderrTail + chunk).slice(-1024);
+    });
+
+    const state = createParserState();
+    let finishedEmitted = false;
+    const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+
+    try {
+      for await (const line of rl) {
+        for (const ev of parseLine(line, state)) {
+          if (ev.type === 'finished') finishedEmitted = true;
+          yield ev;
+        }
+      }
+    } finally {
+      abortSignal?.removeEventListener('abort', onAbort);
+    }
+
+    const exitCode = await exitPromise;
+
+    if (finishedEmitted) return;
+
+    if (spawnError) {
+      yield { type: 'error', message: spawnError.message, recoverable: false };
+      yield finishedEvent('error', ZERO_USAGE, state.sessionId);
+      return;
+    }
+
+    if (aborted) {
+      yield finishedEvent('aborted', ZERO_USAGE, state.sessionId);
+      return;
+    }
+
+    const tail = stderrTail.trim();
+    const message =
+      tail.length > 0
+        ? `claude exited with code ${exitCode} before emitting result. stderr: ${tail}`
+        : `claude exited with code ${exitCode} before emitting result.`;
+    yield { type: 'error', message, recoverable: false };
+    yield finishedEvent('error', ZERO_USAGE, state.sessionId);
+  }
+}
+
+function buildArgs(input: AgentRunInput): readonly string[] {
+  if (input.resumeKey === undefined) return BASE_CLI_ARGS;
+  return [...BASE_CLI_ARGS, '--resume', input.resumeKey];
+}

--- a/packages/adapter-runner-claude-cli/src/index.ts
+++ b/packages/adapter-runner-claude-cli/src/index.ts
@@ -1,0 +1,5 @@
+export {
+  ClaudeCliAgentRunner,
+  type ClaudeCliAgentRunnerOptions,
+  type SpawnFn,
+} from './claude-cli-runner.js';

--- a/packages/adapter-runner-claude-cli/src/stream-parser.test.ts
+++ b/packages/adapter-runner-claude-cli/src/stream-parser.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { AgentEvent } from '@agentry/core';
+import { describe, expect, it } from 'vitest';
+import { createParserState, parseLine } from './stream-parser.js';
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+
+function loadFixture(name: string): string[] {
+  const text = readFileSync(join(fixturesDir, name), 'utf8');
+  return text.split('\n').filter((l) => l.length > 0);
+}
+
+function parseAll(lines: readonly string[]): AgentEvent[] {
+  const state = createParserState();
+  return lines.flatMap((line) => parseLine(line, state));
+}
+
+describe('parseLine — observed fixtures', () => {
+  it('emits text_delta + finished{complete} with usage and resumeKey for a text-only success', () => {
+    const events = parseAll(loadFixture('success-text-only.ndjson'));
+    expect(events).toEqual([
+      { type: 'text_delta', text: '4' },
+      {
+        type: 'finished',
+        reason: 'complete',
+        usage: { input: 5, output: 6, cacheRead: 0, cacheWrite: 45025 },
+        resumeKey: '7adc099b-5d70-4b85-b614-bceb95a7b2e7',
+      },
+    ]);
+  });
+
+  it('emits finished{error} with resumeKey when result.is_error is true', () => {
+    const events = parseAll(loadFixture('error.ndjson'));
+    expect(events).toEqual([
+      {
+        type: 'finished',
+        reason: 'error',
+        usage: { input: 0, output: 0 },
+        resumeKey: 'err-session-001',
+      },
+    ]);
+  });
+});
+
+describe('parseLine — robustness', () => {
+  it('ignores empty lines', () => {
+    expect(parseLine('', createParserState())).toEqual([]);
+    expect(parseLine('   ', createParserState())).toEqual([]);
+  });
+
+  it('ignores malformed JSON', () => {
+    expect(parseLine('{not json', createParserState())).toEqual([]);
+  });
+
+  it('ignores unknown event types', () => {
+    expect(parseLine('{"type":"future_event","data":{}}', createParserState())).toEqual([]);
+  });
+
+  it('captures session_id from any event for use by later finished event', () => {
+    const state = createParserState();
+    parseLine('{"type":"system","subtype":"init","session_id":"abc-123"}', state);
+    expect(state.sessionId).toBe('abc-123');
+    const events = parseLine(
+      '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":1,"output_tokens":2}}',
+      state,
+    );
+    expect(events).toEqual([
+      {
+        type: 'finished',
+        reason: 'complete',
+        usage: { input: 1, output: 2 },
+        resumeKey: 'abc-123',
+      },
+    ]);
+  });
+
+  it('does not include resumeKey when no session_id was seen', () => {
+    const state = createParserState();
+    const events = parseLine(
+      '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":1,"output_tokens":2}}',
+      state,
+    );
+    expect(events).toEqual([
+      { type: 'finished', reason: 'complete', usage: { input: 1, output: 2 } },
+    ]);
+  });
+
+  it('emits multiple text_delta events when content has multiple text blocks', () => {
+    const state = createParserState();
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [
+          { type: 'text', text: 'hello ' },
+          { type: 'text', text: 'world' },
+        ],
+      },
+    });
+    expect(parseLine(line, state)).toEqual([
+      { type: 'text_delta', text: 'hello ' },
+      { type: 'text_delta', text: 'world' },
+    ]);
+  });
+
+  it('maps tool_use blocks to tool_call events (shape unverified)', () => {
+    const state = createParserState();
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        content: [{ type: 'tool_use', name: 'Read', input: { path: '/tmp/x' } }],
+      },
+    });
+    expect(parseLine(line, state)).toEqual([
+      { type: 'tool_call', name: 'Read', input: { path: '/tmp/x' } },
+    ]);
+  });
+});

--- a/packages/adapter-runner-claude-cli/src/stream-parser.test.ts
+++ b/packages/adapter-runner-claude-cli/src/stream-parser.test.ts
@@ -31,9 +31,14 @@ describe('parseLine — observed fixtures', () => {
     ]);
   });
 
-  it('emits finished{error} with resumeKey when result.is_error is true', () => {
+  it('emits error + finished{error} with resumeKey when result.is_error is true', () => {
     const events = parseAll(loadFixture('error.ndjson'));
     expect(events).toEqual([
+      {
+        type: 'error',
+        message: 'claude run reported error: overloaded',
+        recoverable: false,
+      },
       {
         type: 'finished',
         reason: 'error',

--- a/packages/adapter-runner-claude-cli/src/stream-parser.ts
+++ b/packages/adapter-runner-claude-cli/src/stream-parser.ts
@@ -1,0 +1,99 @@
+import type { AgentEvent, TokenUsage } from '@agentry/core';
+
+export interface ParserState {
+  sessionId?: string;
+}
+
+export function createParserState(): ParserState {
+  return {};
+}
+
+export function parseLine(line: string, state: ParserState): AgentEvent[] {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return [];
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return [];
+  }
+
+  if (!isRecord(parsed)) return [];
+
+  if (typeof parsed.session_id === 'string') {
+    state.sessionId = parsed.session_id;
+  }
+
+  switch (parsed.type) {
+    case 'assistant':
+      return parseAssistantMessage(parsed);
+    case 'result':
+      return [parseResult(parsed, state)];
+    default:
+      return [];
+  }
+}
+
+type FinishedEvent = Extract<AgentEvent, { type: 'finished' }>;
+
+export function finishedEvent(
+  reason: FinishedEvent['reason'],
+  usage: TokenUsage,
+  resumeKey?: string,
+): FinishedEvent {
+  return resumeKey === undefined
+    ? { type: 'finished', reason, usage }
+    : { type: 'finished', reason, usage, resumeKey };
+}
+
+function parseAssistantMessage(event: Record<string, unknown>): AgentEvent[] {
+  const message = event.message;
+  if (!isRecord(message)) return [];
+  const content = message.content;
+  if (!Array.isArray(content)) return [];
+
+  const events: AgentEvent[] = [];
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    if (block.type === 'text' && typeof block.text === 'string') {
+      events.push({ type: 'text_delta', text: block.text });
+      continue;
+    }
+    // Shape unverified — `tool_use` blocks were not present in the captured probe.
+    // Mapping follows the Anthropic Messages API contract; revisit when an
+    // observed sample is available.
+    if (block.type === 'tool_use' && typeof block.name === 'string') {
+      events.push({ type: 'tool_call', name: block.name, input: block.input ?? {} });
+    }
+  }
+  return events;
+}
+
+function parseResult(event: Record<string, unknown>, state: ParserState): FinishedEvent {
+  const usage = parseUsage(event.usage);
+  const reason: FinishedEvent['reason'] = event.is_error === true ? 'error' : 'complete';
+  return finishedEvent(reason, usage, state.sessionId);
+}
+
+function parseUsage(raw: unknown): TokenUsage {
+  if (!isRecord(raw)) return { input: 0, output: 0 };
+  const input = asNumber(raw.input_tokens) ?? 0;
+  const output = asNumber(raw.output_tokens) ?? 0;
+  const cacheRead = asNumber(raw.cache_read_input_tokens);
+  const cacheWrite = asNumber(raw.cache_creation_input_tokens);
+  return {
+    input,
+    output,
+    ...(cacheRead !== undefined && { cacheRead }),
+    ...(cacheWrite !== undefined && { cacheWrite }),
+  };
+}
+
+function asNumber(v: unknown): number | undefined {
+  return typeof v === 'number' ? v : undefined;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}

--- a/packages/adapter-runner-claude-cli/src/stream-parser.ts
+++ b/packages/adapter-runner-claude-cli/src/stream-parser.ts
@@ -29,7 +29,7 @@ export function parseLine(line: string, state: ParserState): AgentEvent[] {
     case 'assistant':
       return parseAssistantMessage(parsed);
     case 'result':
-      return [parseResult(parsed, state)];
+      return parseResult(parsed, state);
     default:
       return [];
   }
@@ -70,10 +70,19 @@ function parseAssistantMessage(event: Record<string, unknown>): AgentEvent[] {
   return events;
 }
 
-function parseResult(event: Record<string, unknown>, state: ParserState): FinishedEvent {
+function parseResult(event: Record<string, unknown>, state: ParserState): AgentEvent[] {
   const usage = parseUsage(event.usage);
-  const reason: FinishedEvent['reason'] = event.is_error === true ? 'error' : 'complete';
-  return finishedEvent(reason, usage, state.sessionId);
+  if (event.is_error !== true) {
+    return [finishedEvent('complete', usage, state.sessionId)];
+  }
+  const detail =
+    typeof event.api_error_status === 'string'
+      ? `claude run reported error: ${event.api_error_status}`
+      : 'claude run reported error';
+  return [
+    { type: 'error', message: detail, recoverable: false },
+    finishedEvent('error', usage, state.sessionId),
+  ];
 }
 
 function parseUsage(raw: unknown): TokenUsage {

--- a/packages/adapter-runner-claude-cli/tsconfig.json
+++ b/packages/adapter-runner-claude-cli/tsconfig.json
@@ -6,5 +6,6 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules"]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules", "src/__fixtures__/**"],
+  "references": [{ "path": "../core" }]
 }

--- a/packages/core/src/domain/ids.ts
+++ b/packages/core/src/domain/ids.ts
@@ -1,0 +1,4 @@
+export type SessionId = string;
+export type TurnId = string;
+export type KnowledgeId = string;
+export type TenantId = string;

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -1,0 +1,1 @@
+export type { KnowledgeId, SessionId, TenantId, TurnId } from './ids.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,4 @@
 export const CORE_VERSION = '0.0.0' as const;
+
+export * from './domain/index.js';
+export * from './ports/index.js';

--- a/packages/core/src/ports/agent-runner.ts
+++ b/packages/core/src/ports/agent-runner.ts
@@ -1,0 +1,39 @@
+import type { SessionId } from '../domain/ids.js';
+
+export interface RetrievedItem {
+  readonly text: string;
+  readonly score?: number;
+}
+
+export interface TokenUsage {
+  readonly input: number;
+  readonly output: number;
+  readonly cacheRead?: number;
+  readonly cacheWrite?: number;
+}
+
+export interface AgentRunInput {
+  readonly sessionId: SessionId;
+  readonly workdir: string;
+  readonly prompt: string;
+  readonly resumeKey?: string;
+  readonly context?: { readonly retrievedKnowledge: readonly RetrievedItem[] };
+  readonly abortSignal?: AbortSignal;
+}
+
+export type AgentEvent =
+  | { readonly type: 'text_delta'; readonly text: string }
+  | { readonly type: 'tool_call'; readonly name: string; readonly input: unknown }
+  | { readonly type: 'tool_result'; readonly name: string; readonly output: unknown }
+  | {
+      readonly type: 'finished';
+      readonly reason: 'complete' | 'error' | 'aborted';
+      readonly usage: TokenUsage;
+      readonly resumeKey?: string;
+    }
+  | { readonly type: 'error'; readonly message: string; readonly recoverable: boolean };
+
+export interface AgentRunner {
+  readonly kind: string;
+  run(input: AgentRunInput): AsyncIterable<AgentEvent>;
+}

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -1,0 +1,7 @@
+export type {
+  AgentEvent,
+  AgentRunInput,
+  AgentRunner,
+  RetrievedItem,
+  TokenUsage,
+} from './agent-runner.js';

--- a/packages/testing/src/agent-runner/recording-agent-runner.test.ts
+++ b/packages/testing/src/agent-runner/recording-agent-runner.test.ts
@@ -1,0 +1,25 @@
+import type { AgentEvent, AgentRunInput } from '@agentry/core';
+import { describe, expect, it } from 'vitest';
+import { RecordingAgentRunner } from './recording-agent-runner.js';
+
+const baseInput: AgentRunInput = { sessionId: 's', workdir: '/tmp', prompt: 'hi' };
+
+describe('RecordingAgentRunner', () => {
+  it('plays back the scripted events in order', async () => {
+    const script: AgentEvent[] = [
+      { type: 'text_delta', text: 'hello' },
+      { type: 'finished', reason: 'complete', usage: { input: 1, output: 1 } },
+    ];
+    const runner = new RecordingAgentRunner(script);
+    const collected: AgentEvent[] = [];
+    for await (const ev of runner.run(baseInput)) collected.push(ev);
+    expect(collected).toEqual(script);
+  });
+
+  it('records each input it is invoked with', async () => {
+    const runner = new RecordingAgentRunner();
+    for await (const _ of runner.run(baseInput)) void _;
+    for await (const _ of runner.run({ ...baseInput, prompt: 'second' })) void _;
+    expect(runner.inputs.map((i) => i.prompt)).toEqual(['hi', 'second']);
+  });
+});

--- a/packages/testing/src/agent-runner/recording-agent-runner.ts
+++ b/packages/testing/src/agent-runner/recording-agent-runner.ts
@@ -1,0 +1,13 @@
+import type { AgentEvent, AgentRunInput, AgentRunner } from '@agentry/core';
+
+export class RecordingAgentRunner implements AgentRunner {
+  readonly kind = 'recording';
+  readonly inputs: AgentRunInput[] = [];
+
+  constructor(private readonly events: readonly AgentEvent[] = []) {}
+
+  async *run(input: AgentRunInput): AsyncIterable<AgentEvent> {
+    this.inputs.push(input);
+    for (const ev of this.events) yield ev;
+  }
+}

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -1,1 +1,3 @@
 export const TESTING_VERSION = '0.0.0' as const;
+
+export { RecordingAgentRunner } from './agent-runner/recording-agent-runner.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,21 @@ importers:
         specifier: ^24.0.0
         version: 24.12.2
 
-  packages/core: {}
+  packages/adapter-runner-claude-cli:
+    dependencies:
+      '@agentry/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
+
+  packages/core:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
 
   packages/runtime:
     dependencies:
@@ -419,6 +433,9 @@ packages:
 
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -809,6 +826,9 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1118,6 +1138,10 @@ snapshots:
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -1489,6 +1513,8 @@ snapshots:
   typescript@6.0.3: {}
 
   undici-types@7.16.0: {}
+
+  undici-types@7.19.2: {}
 
   vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0):
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "paths": {
       "@agentry/core": ["packages/core/src/index.ts"],
       "@agentry/runtime": ["packages/runtime/src/index.ts"],
-      "@agentry/testing": ["packages/testing/src/index.ts"]
+      "@agentry/testing": ["packages/testing/src/index.ts"],
+      "@agentry/adapter-runner-claude-cli": ["packages/adapter-runner-claude-cli/src/index.ts"]
     }
   },
   "files": [],
@@ -12,6 +13,7 @@
     { "path": "packages/core" },
     { "path": "packages/testing" },
     { "path": "packages/runtime" },
+    { "path": "packages/adapter-runner-claude-cli" },
     { "path": "apps/server" },
     { "path": "apps/cli" }
   ]


### PR DESCRIPTION
Closes #19. Lifts the AgentRunner port shape from ARCHITECTURE.md §4.2 into TypeScript and ships the first adapter implementing it.

## Summary

- **`packages/core/src/ports/agent-runner.ts`** — `AgentRunner`, `AgentRunInput`, `AgentEvent`, `TokenUsage`, `RetrievedItem`. First port code in the workspace; subsequent adapters extend the port surface.
- **`packages/core/src/domain/ids.ts`** — `SessionId` / `TurnId` / `KnowledgeId` / `TenantId` type aliases (branded variants deferred to a follow-up).
- **`packages/adapter-runner-claude-cli`** — `ClaudeCliAgentRunner` implementing `AgentRunner`. Spawns `claude -p --output-format stream-json --verbose --input-format text [--resume <uuid>]`, parses NDJSON stdout via `node:readline`, maps events to `AgentEvent`s.
- **`packages/testing/src/agent-runner/recording-agent-runner.ts`** — `RecordingAgentRunner` for use-case tests, with input recording and scripted event playback.
- **`.dependency-cruiser.cjs`** — adapter rule generalised with a `$1` backreference (`from: '^packages/(adapter-[^/]+)/'`, `to.pathNot: '^packages/(core|$1)/'`) so each adapter package is allowed to import from itself or core, but not from other adapters or runtime/apps. Replaces the previous flat rule which incorrectly flagged intra-package imports.

## Event mapping (verified)

| stream-json line | Emitted `AgentEvent` |
|---|---|
| `system.init` | (captures `session_id` for `resumeKey`) |
| `assistant.message.content[].type='text'` | `{ type: 'text_delta', text }` |
| `assistant.message.content[].type='tool_use'` | `{ type: 'tool_call', name, input }` *(shape unverified — no observed sample yet)* |
| `result.subtype='success'` | `{ type: 'finished', reason: 'complete', usage, resumeKey }` |
| `result.is_error=true` | `error{...}` + `finished{reason:'error'}` |
| `AbortSignal` | SIGTERM → `finished{reason:'aborted'}` |
| spawn error / exit-without-result | `error{...}` + `finished{reason:'error'}` |

All failure paths emit the same `error` + `finished{error}` pair so consumers can filter uniformly on `ev.type === 'error'`.

## Verification

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 30/30 pass (16 in adapter-runner-claude-cli, 11 in runtime/config from #27, 2 in RecordingAgentRunner, 1 in core)
- [x] `pnpm lint` (Biome) clean
- [x] `pnpm depcheck` 0 errors (2 pre-existing `no-orphans` warnings on stub app entry files)
- [x] **Live smoke test** against real `claude` binary:
  ```
  {"type":"text_delta","text":"OK"}
  {"type":"finished","reason":"complete","usage":{"input":6,"output":6,"cacheRead":17360,"cacheWrite":25155},"resumeKey":"ae04cde4-..."}
  ```
- [x] Resume via `--resume <uuid>` round-trips a 2-message session (probed before implementation)

## Decisions worth flagging

- **Subprocess injection** — `ClaudeCliAgentRunner` accepts an optional `spawn?: SpawnFn` for testability. Default is `child_process.spawn`. Tests use a `FakeChildProcess` (PassThrough streams + EventEmitter).
- **Prompt via stdin** — argv-safe regardless of prompt size.
- **`process.env` passthrough** — child claude inherits parent env. Documented in CLAUDE.md / config docs as the intended trust boundary.
- **SIGTERM only** — no SIGKILL escalation in MVP. claude CLI handles SIGTERM cleanly. Follow-up: timer-based escalation if a runaway is observed in the wild.
- **`@types/node` added to `packages/core` as devDep + `types: ["node"]` in tsconfig** — needed for `AbortSignal` global typing under TypeScript 6.0.3 lib `ES2024`. devDep only; runtime deps for core remain zero.

## Scope cuts (intentional, follow-ups)

- Logger port wiring — silent skip on parse error; revisit once a Logger adapter lands.
- Branded ID types — string aliases for now.
- Subprocess pooling — ARCHITECTURE.md §8 explicitly defers this.
- SIGKILL escalation timer.
- `tool_use` shape verification against an observed sample (will fix forward when one shows up).
- `--add-dir`, `--permission-mode`, `--mcp-config` runner options.

## Test plan

- [ ] Reviewer runs the smoke test snippet from the verification section locally to confirm the flag combo works in their environment
- [ ] `pnpm typecheck && pnpm test && pnpm lint && pnpm depcheck` on a clean checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)