### PR TITLE
feat(cli): wire `agentry migrate` and relax apps boundary (#33)

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -1,6 +1,7 @@
 /**
  * dependency-cruiser config — enforces ARCHITECTURE.md §6 layer rules.
- * core ← (testing | adapter-* | runtime); runtime ← apps; nothing else crosses.
+ * core ← (testing | adapter-* | runtime | apps); apps may also wire adapters
+ * directly as the composition root (§7); testing is unit-test-only.
  */
 module.exports = {
   forbidden: [
@@ -36,11 +37,12 @@ module.exports = {
       to: { path: '^apps/' },
     },
     {
-      name: 'apps-only-from-runtime',
+      name: 'apps-no-testing',
       severity: 'error',
-      comment: 'apps may only import from runtime (which re-exports core where needed).',
+      comment:
+        'apps act as the composition root (ARCHITECTURE.md §7): they may import core, runtime, and adapter-* directly. runtime is convenience, not a chokepoint — but never test-only utilities.',
       from: { path: '^apps/' },
-      to: { path: '^packages/(?!runtime/)' },
+      to: { path: '^packages/testing/' },
     },
     {
       name: 'no-circular',

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,13 +7,18 @@
     "agentry": "./dist/main.js"
   },
   "scripts": {
-    "build": "tsc -b",
-    "dev": "tsx src/main.ts"
+    "build": "tsc -b && chmod +x dist/main.js",
+    "dev": "tsx src/main.ts",
+    "test": "vitest run"
   },
   "dependencies": {
+    "@agentry/adapter-store-pgvector": "workspace:*",
     "@agentry/runtime": "workspace:*"
   },
   "devDependencies": {
-    "@types/node": "^24.0.0"
+    "@types/node": "^24.0.0",
+    "@types/pg": "^8.15.5",
+    "pg": "^8.16.0",
+    "testcontainers": "^11.7.0"
   }
 }

--- a/apps/cli/src/__integration__/migrate.integration.test.ts
+++ b/apps/cli/src/__integration__/migrate.integration.test.ts
@@ -1,0 +1,74 @@
+import { Client } from 'pg';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { runCli } from '../cli.js';
+
+const integration = process.env.INTEGRATION === '1';
+
+describe.skipIf(!integration)('agentry migrate (CLI e2e)', () => {
+  let container: StartedTestContainer;
+  let databaseUrl: string;
+
+  beforeAll(async () => {
+    container = await new GenericContainer('pgvector/pgvector:pg17')
+      .withEnvironment({
+        POSTGRES_USER: 'agentry',
+        POSTGRES_PASSWORD: 'agentry',
+        POSTGRES_DB: 'agentry',
+      })
+      .withExposedPorts(5432)
+      .withWaitStrategy(Wait.forLogMessage(/database system is ready to accept connections/, 2))
+      .start();
+
+    const host = container.getHost();
+    const port = container.getMappedPort(5432);
+    databaseUrl = `postgres://agentry:agentry@${host}:${port}/agentry`;
+  }, 120_000);
+
+  afterAll(async () => {
+    if (container) await container.stop();
+  });
+
+  it('applies migrations against a real container', async () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    const code = await runCli(
+      ['migrate'],
+      { POSTGRES_URL: databaseUrl, EMBEDDING_DIM: '1024' },
+      {
+        out: (m) => out.push(m),
+        err: (m) => err.push(m),
+      },
+    );
+    expect(code).toBe(0);
+    expect(err).toEqual([]);
+    expect(out.join('\n')).toMatch(/applied: 1, skipped: 0/);
+
+    const client = new Client({ connectionString: databaseUrl });
+    await client.connect();
+    try {
+      const r = await client.query<{ count: string }>(
+        "SELECT count(*)::text FROM tenants WHERE id = 'default'",
+      );
+      expect(r.rows[0]?.count).toBe('1');
+    } finally {
+      await client.end();
+    }
+  });
+
+  it('is idempotent on second invocation', async () => {
+    const out: string[] = [];
+    const code = await runCli(
+      ['migrate'],
+      { POSTGRES_URL: databaseUrl },
+      {
+        out: (m) => out.push(m),
+        err: (m) => {
+          throw new Error(`unexpected stderr: ${m}`);
+        },
+      },
+    );
+    expect(code).toBe(0);
+    expect(out.join('\n')).toMatch(/applied: 0, skipped: 1/);
+  });
+});

--- a/apps/cli/src/cli.test.ts
+++ b/apps/cli/src/cli.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { runCli } from './cli.js';
+
+function captureIo(): {
+  out: string[];
+  err: string[];
+  io: { out: (m: string) => void; err: (m: string) => void };
+} {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    io: {
+      out: (m) => out.push(m),
+      err: (m) => err.push(m),
+    },
+  };
+}
+
+describe('runCli', () => {
+  it('prints usage and exits 1 when no command is given', async () => {
+    const { err, io } = captureIo();
+    const code = await runCli([], {}, io);
+    expect(code).toBe(1);
+    expect(err.join('\n')).toMatch(/Usage: agentry <command>/);
+  });
+
+  it('prints usage and exits 1 on unknown command', async () => {
+    const { err, io } = captureIo();
+    const code = await runCli(['unknown'], {}, io);
+    expect(code).toBe(1);
+    expect(err.join('\n')).toMatch(/Usage: agentry <command>/);
+  });
+
+  it('migrate fails fast when POSTGRES_URL is missing', async () => {
+    const { err, io } = captureIo();
+    const code = await runCli(['migrate'], {}, io);
+    expect(code).toBe(1);
+    expect(err.join('\n')).toMatch(/POSTGRES_URL/);
+  });
+
+  it('migrate fails fast on non-numeric EMBEDDING_DIM', async () => {
+    const { err, io } = captureIo();
+    const code = await runCli(
+      ['migrate'],
+      { POSTGRES_URL: 'postgres://x', EMBEDDING_DIM: 'not-a-number' },
+      io,
+    );
+    expect(code).toBe(1);
+    expect(err.join('\n')).toMatch(/EMBEDDING_DIM/);
+  });
+
+  it('migrate fails fast on zero EMBEDDING_DIM', async () => {
+    const { err, io } = captureIo();
+    const code = await runCli(
+      ['migrate'],
+      { POSTGRES_URL: 'postgres://x', EMBEDDING_DIM: '0' },
+      io,
+    );
+    expect(code).toBe(1);
+    expect(err.join('\n')).toMatch(/EMBEDDING_DIM/);
+  });
+});

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,0 +1,68 @@
+import { runMigrations } from '@agentry/adapter-store-pgvector';
+
+const USAGE = `Usage: agentry <command>
+
+Commands:
+  migrate    Apply Postgres + pgvector schema migrations.
+             Required env: POSTGRES_URL
+             Optional env: EMBEDDING_DIM (default: 1024)
+`;
+
+const DEFAULT_EMBEDDING_DIM = 1024;
+
+export interface RunCliIo {
+  readonly out: (msg: string) => void;
+  readonly err: (msg: string) => void;
+}
+
+const DEFAULT_IO: RunCliIo = {
+  out: (msg) => {
+    console.log(msg);
+  },
+  err: (msg) => {
+    console.error(msg);
+  },
+};
+
+export async function runCli(
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+  io: RunCliIo = DEFAULT_IO,
+): Promise<number> {
+  const command = argv[0];
+
+  if (command === 'migrate') {
+    return migrateCommand(env, io);
+  }
+
+  io.err(USAGE);
+  return 1;
+}
+
+async function migrateCommand(env: NodeJS.ProcessEnv, io: RunCliIo): Promise<number> {
+  const databaseUrl = env.POSTGRES_URL;
+  if (!databaseUrl) {
+    io.err('POSTGRES_URL must be set in the environment');
+    return 1;
+  }
+
+  const rawDim = env.EMBEDDING_DIM;
+  const embeddingDim = rawDim === undefined ? DEFAULT_EMBEDDING_DIM : Number(rawDim);
+  if (!Number.isInteger(embeddingDim) || embeddingDim <= 0) {
+    io.err(`EMBEDDING_DIM must be a positive integer, got ${String(rawDim)}`);
+    return 1;
+  }
+
+  try {
+    const result = await runMigrations({
+      databaseUrl,
+      embeddingDim,
+      logger: io.out,
+    });
+    io.out(`migrate done — applied: ${result.applied.length}, skipped: ${result.skipped.length}`);
+    return 0;
+  } catch (err) {
+    io.err(`migrate failed: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,3 +1,10 @@
 #!/usr/bin/env node
-console.log('agentry CLI: bootstrap stub');
-process.exit(0);
+import { runCli } from './cli.js';
+
+runCli(process.argv.slice(2)).then(
+  (code) => process.exit(code),
+  (err: unknown) => {
+    console.error(err);
+    process.exit(1);
+  },
+);

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -9,6 +9,9 @@
     "types": ["node"]
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules"],
-  "references": [{ "path": "../../packages/runtime" }]
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "src/__integration__/**", "dist", "node_modules"],
+  "references": [
+    { "path": "../../packages/runtime" },
+    { "path": "../../packages/adapter-store-pgvector" }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   apps/cli:
     dependencies:
+      '@agentry/adapter-store-pgvector':
+        specifier: workspace:*
+        version: link:../../packages/adapter-store-pgvector
       '@agentry/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
@@ -36,6 +39,15 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.12.2
+      '@types/pg':
+        specifier: ^8.15.5
+        version: 8.20.0
+      pg:
+        specifier: ^8.16.0
+        version: 8.20.0
+      testcontainers:
+        specifier: ^11.7.0
+        version: 11.14.0
 
   apps/server:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #33. Two coupled changes that finish the loose end from #20:

1. **Relax `apps-only-from-runtime` rule** → `apps-no-testing`. apps now act as the composition root (per ARCHITECTURE.md §7) and may import `core`, `runtime`, and `adapter-*` directly. Only `packages/testing` remains forbidden.
2. **Wire `agentry migrate` subcommand** in `apps/cli`. Reads env, calls `runMigrations` from `@agentry/adapter-store-pgvector`.

## Why this couldn't ship with #20

The depcheck rule blocked apps from importing the new adapter directly. Workaround would have been to re-export `runMigrations` through `runtime`, but `runtime` is meant to expose composition primitives, not concrete adapters. Splitting was the right call.

## Files

- `.dependency-cruiser.cjs`: rule replacement + comment explaining composition-root intent
- `apps/cli/src/cli.ts`: testable `runCli(argv, env, io)` with captured stdout/stderr
- `apps/cli/src/main.ts`: thin bin entry that calls `runCli` and exits
- `apps/cli/src/cli.test.ts`: unit tests — usage, missing `POSTGRES_URL`, bad `EMBEDDING_DIM`
- `apps/cli/src/__integration__/migrate.integration.test.ts`: e2e against testcontainers `pgvector/pgvector:pg17`
- `apps/cli/package.json`: adds `@agentry/adapter-store-pgvector` dep + `chmod +x` postbuild for the bin
- `apps/cli/tsconfig.json`: adds adapter package reference, excludes integration dir

## env contract

| Var | Required | Default | Source of truth |
|---|---|---|---|
| `POSTGRES_URL` | yes | — | `SecretsSchema` (`packages/runtime/src/config/secrets.ts`) |
| `EMBEDDING_DIM` | no | `1024` | Voyage `voyage-3` dim per ARCHITECTURE.md |

`agentry migrate` does **not** call `loadSecrets()` because that would force operators to set Slack/Voyage tokens just to bootstrap the database. `migrate` reads `POSTGRES_URL` directly with a clear "must be set" error if absent.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 44 passed | 6 skipped (CLI + adapter integration tests gated)
- [x] `INTEGRATION=1 pnpm --filter @agentry/cli test` 7 passed (Docker required)
- [x] `pnpm depcheck` passes (only pre-existing `apps/server/main.ts` orphan warning remains)
- [x] `pnpm --filter @agentry/cli build` produces `dist/main.js` with shebang + executable bit; `./apps/cli/dist/main.js` prints usage

## Related

- Closes #33
- Follow-up to #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)