### PR TITLE
feat(jobrunner): lift JobRunner port + in-memory adapter (#38)

### DIFF
--- a/packages/adapter-jobrunner-memory/package.json
+++ b/packages/adapter-jobrunner-memory/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@agentry/adapter-jobrunner-memory",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@agentry/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.2"
+  }
+}

--- a/packages/adapter-jobrunner-memory/src/in-memory-job-runner.test.ts
+++ b/packages/adapter-jobrunner-memory/src/in-memory-job-runner.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InMemoryJobRunner } from './in-memory-job-runner.js';
+
+interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// Drain ALL pending microtasks by waiting for the next macrotask boundary.
+// `setImmediate` fires after every microtask has settled, which is enough
+// for our chained `.then().catch().finally()` plus user-job awaits.
+async function settle(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+describe('InMemoryJobRunner', () => {
+  it('serializes jobs sharing a key in FIFO order', async () => {
+    const runner = new InMemoryJobRunner();
+    const order: string[] = [];
+    const gateA = deferred<void>();
+    const gateB = deferred<void>();
+
+    await runner.enqueue({
+      key: 'session-1',
+      job: async () => {
+        order.push('a:start');
+        await gateA.promise;
+        order.push('a:end');
+      },
+    });
+    await runner.enqueue({
+      key: 'session-1',
+      job: async () => {
+        order.push('b:start');
+        await gateB.promise;
+        order.push('b:end');
+      },
+    });
+
+    await settle();
+    expect(order).toEqual(['a:start']);
+
+    gateA.resolve();
+    await settle();
+    expect(order).toEqual(['a:start', 'a:end', 'b:start']);
+
+    gateB.resolve();
+    await settle();
+    expect(order).toEqual(['a:start', 'a:end', 'b:start', 'b:end']);
+  });
+
+  it('runs jobs on different keys in parallel', async () => {
+    const runner = new InMemoryJobRunner();
+    const order: string[] = [];
+    const gateA = deferred<void>();
+    const gateB = deferred<void>();
+
+    await runner.enqueue({
+      key: 'session-1',
+      job: async () => {
+        order.push('a:start');
+        await gateA.promise;
+        order.push('a:end');
+      },
+    });
+    await runner.enqueue({
+      key: 'session-2',
+      job: async () => {
+        order.push('b:start');
+        await gateB.promise;
+        order.push('b:end');
+      },
+    });
+
+    await settle();
+    // Both started — different keys do not block each other.
+    expect(order).toEqual(['a:start', 'b:start']);
+
+    gateB.resolve();
+    await settle();
+    expect(order).toEqual(['a:start', 'b:start', 'b:end']);
+
+    gateA.resolve();
+    await settle();
+    expect(order).toEqual(['a:start', 'b:start', 'b:end', 'a:end']);
+  });
+
+  it('continues the chain after a job throws', async () => {
+    const onError = vi.fn();
+    const runner = new InMemoryJobRunner({ onError });
+    const order: string[] = [];
+
+    await runner.enqueue({
+      key: 'k',
+      job: async () => {
+        throw new Error('boom');
+      },
+    });
+    await runner.enqueue({
+      key: 'k',
+      job: async () => {
+        order.push('after-error');
+      },
+    });
+
+    await runner.drain();
+    expect(order).toEqual(['after-error']);
+    expect(onError).toHaveBeenCalledTimes(1);
+    const [err, key] = onError.mock.calls[0] ?? [];
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('boom');
+    expect(key).toBe('k');
+  });
+
+  it('swallows errors thrown by the onError handler itself', async () => {
+    const runner = new InMemoryJobRunner({
+      onError: () => {
+        throw new Error('handler-failed');
+      },
+    });
+    const order: string[] = [];
+
+    await runner.enqueue({
+      key: 'k',
+      job: async () => {
+        throw new Error('boom');
+      },
+    });
+    await runner.enqueue({
+      key: 'k',
+      job: async () => {
+        order.push('after');
+      },
+    });
+
+    await runner.drain();
+    expect(order).toEqual(['after']);
+  });
+
+  it('resolves enqueue immediately, before the job completes', async () => {
+    const runner = new InMemoryJobRunner();
+    const gate = deferred<void>();
+    let started = false;
+    let finished = false;
+
+    const enqueuePromise = runner.enqueue({
+      key: 'k',
+      job: async () => {
+        started = true;
+        await gate.promise;
+        finished = true;
+      },
+    });
+
+    await enqueuePromise;
+    // The job may have started its first microtask but cannot have finished.
+    expect(finished).toBe(false);
+
+    await settle();
+    expect(started).toBe(true);
+    expect(finished).toBe(false);
+
+    gate.resolve();
+    await runner.drain();
+    expect(finished).toBe(true);
+  });
+
+  it('drain waits for in-flight jobs across multiple keys', async () => {
+    const runner = new InMemoryJobRunner();
+    const gateA = deferred<void>();
+    const gateB = deferred<void>();
+    let aDone = false;
+    let bDone = false;
+
+    await runner.enqueue({
+      key: 'a',
+      job: async () => {
+        await gateA.promise;
+        aDone = true;
+      },
+    });
+    await runner.enqueue({
+      key: 'b',
+      job: async () => {
+        await gateB.promise;
+        bDone = true;
+      },
+    });
+
+    queueMicrotask(() => {
+      gateA.resolve();
+      gateB.resolve();
+    });
+
+    await runner.drain();
+    expect(aDone).toBe(true);
+    expect(bDone).toBe(true);
+  });
+});

--- a/packages/adapter-jobrunner-memory/src/in-memory-job-runner.ts
+++ b/packages/adapter-jobrunner-memory/src/in-memory-job-runner.ts
@@ -1,0 +1,52 @@
+import type { JobRunner, JobRunnerEnqueueOptions } from '@agentry/core';
+
+export interface InMemoryJobRunnerOptions {
+  // Invoked once per job rejection. The chain continues regardless — a
+  // failing job must NOT poison subsequent jobs on the same key. Errors
+  // thrown by the handler itself are swallowed.
+  readonly onError?: (err: unknown, key: string) => void;
+}
+
+// Single-process per-key serializer. Same key → FIFO chain; different keys
+// run independently. Swap to pg-boss / BullMQ when crossing process boundaries
+// (see ARCHITECTURE.md §4.8).
+export class InMemoryJobRunner implements JobRunner {
+  private readonly chains = new Map<string, Promise<void>>();
+
+  constructor(private readonly options: InMemoryJobRunnerOptions = {}) {}
+
+  async enqueue(opts: JobRunnerEnqueueOptions): Promise<void> {
+    const key = opts.key;
+    const job = opts.job;
+    const previous = this.chains.get(key) ?? Promise.resolve();
+    const onError = this.options.onError;
+    const next: Promise<void> = previous
+      .then(() => job())
+      .catch((err: unknown) => {
+        if (onError) {
+          try {
+            onError(err, key);
+          } catch {
+            // swallow — handler errors must not poison the chain
+          }
+        }
+      })
+      .finally(() => {
+        // Drop the chain entry only if no later enqueue has replaced it.
+        if (this.chains.get(key) === next) {
+          this.chains.delete(key);
+        }
+      });
+    this.chains.set(key, next);
+  }
+
+  // Wait for every in-flight chain to drain. Loops because a job may enqueue
+  // another while we await — graceful shutdown still has to settle them.
+  // Caller is responsible for ensuring enqueued jobs terminate; otherwise
+  // drain never returns.
+  async drain(): Promise<void> {
+    while (this.chains.size > 0) {
+      await Promise.all([...this.chains.values()]);
+    }
+  }
+}

--- a/packages/adapter-jobrunner-memory/src/index.ts
+++ b/packages/adapter-jobrunner-memory/src/index.ts
@@ -1,0 +1,2 @@
+export type { InMemoryJobRunnerOptions } from './in-memory-job-runner.js';
+export { InMemoryJobRunner } from './in-memory-job-runner.js';

--- a/packages/adapter-jobrunner-memory/tsconfig.json
+++ b/packages/adapter-jobrunner-memory/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -5,4 +5,8 @@ export type {
   RetrievedItem,
   TokenUsage,
 } from './agent-runner.js';
+export type {
+  JobRunner,
+  JobRunnerEnqueueOptions,
+} from './job-runner.js';
 export type { KnowledgeStore } from './knowledge-store.js';

--- a/packages/core/src/ports/job-runner.ts
+++ b/packages/core/src/ports/job-runner.ts
@@ -1,0 +1,11 @@
+export interface JobRunnerEnqueueOptions {
+  readonly key: string;
+  readonly job: () => Promise<void>;
+}
+
+// Per-key serialization primitive: same `key` runs FIFO, different keys
+// run in parallel. `enqueue` resolves once the job is queued, NOT after it
+// completes — back-pressure is not part of this contract.
+export interface JobRunner {
+  enqueue(opts: JobRunnerEnqueueOptions): Promise<void>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,16 @@ importers:
         specifier: ^24.0.0
         version: 24.12.2
 
+  packages/adapter-jobrunner-memory:
+    dependencies:
+      '@agentry/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
+
   packages/adapter-runner-claude-cli:
     dependencies:
       '@agentry/core':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
       "@agentry/runtime": ["packages/runtime/src/index.ts"],
       "@agentry/testing": ["packages/testing/src/index.ts"],
       "@agentry/adapter-runner-claude-cli": ["packages/adapter-runner-claude-cli/src/index.ts"],
+      "@agentry/adapter-jobrunner-memory": ["packages/adapter-jobrunner-memory/src/index.ts"],
       "@agentry/adapter-store-pgvector": ["packages/adapter-store-pgvector/src/index.ts"]
     }
   },
@@ -15,6 +16,7 @@
     { "path": "packages/testing" },
     { "path": "packages/runtime" },
     { "path": "packages/adapter-runner-claude-cli" },
+    { "path": "packages/adapter-jobrunner-memory" },
     { "path": "packages/adapter-store-pgvector" },
     { "path": "apps/server" },
     { "path": "apps/cli" }


### PR DESCRIPTION
## Summary

Closes #38. Lifts the `JobRunner` port (ARCHITECTURE.md §4.8) into TypeScript code in `packages/core` and ships the MVP single-process adapter as `@agentry/adapter-jobrunner-memory`. Building block for #21 (minimal end-to-end Q&A flow) — per-key serialization is what keeps back-to-back messages in the same Slack thread from racing on `recordTurn` and parallel agent invocations.

## Files

`packages/core/src/ports/job-runner.ts`:
- `JobRunnerEnqueueOptions` (`{ key, job }`), `JobRunner` (`enqueue` only)

`packages/adapter-jobrunner-memory/`:
- `src/in-memory-job-runner.ts` — `Map<key, Promise>` chain + `onError` hook + `drain()` for shutdown
- `src/in-memory-job-runner.test.ts` — 6 tests (no timers, deferred promises only)
- standard adapter scaffold

## Behavioral contract

- `enqueue` resolves immediately after queueing. Fire-and-forget.
- Same `key` → strict FIFO. Different keys → parallel.
- A failing job does **not** poison subsequent jobs on the same key.
- Errors surface via the optional `onError(err, key)` ctor callback. Errors thrown inside `onError` are swallowed (handler errors must not poison the chain).
- `drain()` (adapter-only, not on the port) awaits all in-flight chains. Loops because a job may enqueue another. Caller is responsible for ensuring jobs terminate.

## Canonical wiring (composition root)

```ts
import { InMemoryJobRunner } from '@agentry/adapter-jobrunner-memory';

const jobs = new InMemoryJobRunner({
  onError: (err, key) => logger.error({ err, key }, 'job failed'),
});

// enqueue and return — handler can safely ack the inbound webhook
await jobs.enqueue({ key: sessionId, job: () => processOneTurn(event) });
```

## Out of scope

- Cross-process queue (pg-boss, BullMQ) — Phase 5 #28
- Logger port + adapter — composition concern, separate issue when needed
- Distillation triggers — Phase 2 use cases

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 52 passed | 6 skipped (6 new)
- [x] `pnpm lint` clean
- [x] `pnpm depcheck` passes (only pre-existing `apps/server/main.ts` orphan warning)

## Related

- Closes #38
- ARCHITECTURE.md §4.8 (port design closed in #25)
- Building block toward #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)