### PR TITLE
feat(core): lift SessionStore port + session/turn domain types (#40)

### DIFF
--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -19,4 +19,14 @@ export type {
   RetrievalResult,
   RetrievedKnowledgeItem,
 } from './retrieval.js';
+export type {
+  AuthorRole,
+  ChannelKind,
+  ChannelNativeRef,
+  DistillationCriteria,
+  Session,
+  SessionStatus,
+  Turn,
+  TurnInput,
+} from './session.js';
 export type { SourceKind, SourceRef, SourceRefInput } from './source.js';

--- a/packages/core/src/domain/session.ts
+++ b/packages/core/src/domain/session.ts
@@ -1,0 +1,59 @@
+import type { SessionId, TenantId, TurnId } from './ids.js';
+
+// Open string: 'slack' | 'slack-dm' | 'discord' | 'cli' | 'http' | …
+// Each channel adapter declares its own value; the framework treats it
+// opaquely except for `(tenant_id, channel_kind, channel_native_ref)`
+// uniqueness in the schema.
+export type ChannelKind = string;
+
+// Channel-specific session reference. Per the per-channel policy table in
+// ARCHITECTURE.md §4.3, e.g. `slack:${channel_id}:${thread_ts}`.
+export type ChannelNativeRef = string;
+
+export type SessionStatus = 'active' | 'idle' | 'ended';
+
+export type AuthorRole = 'user' | 'agent' | 'system';
+
+export interface Session {
+  readonly id: SessionId;
+  readonly tenantId: TenantId;
+  readonly channelKind: ChannelKind;
+  readonly channelNativeRef: ChannelNativeRef;
+  readonly startedAt: Date;
+  readonly lastActiveAt: Date;
+  readonly status: SessionStatus;
+  // JSONB array — channel adapters store whatever shape suits them
+  // (Slack user IDs as plain strings, Discord member objects, etc.).
+  readonly participants: readonly unknown[];
+  readonly metadata: Readonly<Record<string, unknown>>;
+  // Distillation watermark — turns with seq_no <= this have been processed.
+  readonly distilledThroughSeqNo: bigint;
+}
+
+export interface TurnInput {
+  readonly authorRole: AuthorRole;
+  readonly authorRef?: Readonly<Record<string, unknown>>;
+  readonly contentText: string;
+  readonly contentExtra?: Readonly<Record<string, unknown>>;
+  // Token usage, tool-call summaries, etc.
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
+export interface Turn extends TurnInput {
+  readonly id: TurnId;
+  readonly seqNo: bigint;
+  readonly sessionId: SessionId;
+  readonly createdAt: Date;
+}
+
+// Trigger taxonomy from `docs/design/knowledge-store.md` §5.1. `rolling` is
+// disabled by default; see design doc for per-trigger policy.
+export type DistillationCriteria =
+  | { readonly kind: 'session_ended'; readonly sessionId: SessionId }
+  | { readonly kind: 'idle'; readonly idleSinceMin: number }
+  | { readonly kind: 'manual'; readonly sessionId: SessionId }
+  | {
+      readonly kind: 'rolling';
+      readonly sessionId: SessionId;
+      readonly everyNTurns: number;
+    };

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -10,3 +10,4 @@ export type {
   JobRunnerEnqueueOptions,
 } from './job-runner.js';
 export type { KnowledgeStore } from './knowledge-store.js';
+export type { SessionStore } from './session-store.js';

--- a/packages/core/src/ports/session-store.test.ts
+++ b/packages/core/src/ports/session-store.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  ChannelKind,
+  ChannelNativeRef,
+  DistillationCriteria,
+  Session,
+  SessionId,
+  SessionStatus,
+  TenantId,
+  Turn,
+  TurnInput,
+} from '../index.js';
+import type { SessionStore } from './session-store.js';
+
+// Compile + runtime smoke: a minimal in-memory implementation proves the
+// interface is implementable without false constraints. Concrete adapter
+// (PgvectorSessionStore) lands in its own package.
+function buildFake(): SessionStore {
+  const sessions = new Map<SessionId, Session>();
+  const turnsBySession = new Map<SessionId, Turn[]>();
+  const sessionByKey = new Map<string, SessionId>();
+  let sessionCounter = 0;
+  let turnCounter = 0;
+  let nextSeq = 1n;
+
+  return {
+    async findOrCreate(
+      channelKind: ChannelKind,
+      channelNativeRef: ChannelNativeRef,
+      tenantId: TenantId,
+    ): Promise<Session> {
+      const key = `${tenantId}|${channelKind}|${channelNativeRef}`;
+      const existingId = sessionByKey.get(key);
+      const existing = existingId ? sessions.get(existingId) : undefined;
+      if (existing) return existing;
+
+      sessionCounter += 1;
+      const now = new Date();
+      const session: Session = {
+        id: `sess-${sessionCounter}`,
+        tenantId,
+        channelKind,
+        channelNativeRef,
+        startedAt: now,
+        lastActiveAt: now,
+        status: 'active',
+        participants: [],
+        metadata: {},
+        distilledThroughSeqNo: 0n,
+      };
+      sessions.set(session.id, session);
+      sessionByKey.set(key, session.id);
+      turnsBySession.set(session.id, []);
+      return session;
+    },
+
+    async recordTurn(sessionId: SessionId, input: TurnInput): Promise<Turn> {
+      turnCounter += 1;
+      const turn: Turn = {
+        ...input,
+        id: `turn-${turnCounter}`,
+        seqNo: nextSeq,
+        sessionId,
+        createdAt: new Date(),
+      };
+      nextSeq += 1n;
+      const list = turnsBySession.get(sessionId) ?? [];
+      list.push(turn);
+      turnsBySession.set(sessionId, list);
+      return turn;
+    },
+
+    async getRecentTurns(sessionId: SessionId, limit: number): Promise<readonly Turn[]> {
+      const all = turnsBySession.get(sessionId) ?? [];
+      return all.slice(-limit);
+    },
+
+    async updateStatus(sessionId: SessionId, status: SessionStatus): Promise<void> {
+      const existing = sessions.get(sessionId);
+      if (!existing) return;
+      sessions.set(sessionId, { ...existing, status });
+    },
+
+    async setMetadata(
+      sessionId: SessionId,
+      patch: Readonly<Record<string, unknown>>,
+    ): Promise<void> {
+      const existing = sessions.get(sessionId);
+      if (!existing) return;
+      sessions.set(sessionId, {
+        ...existing,
+        metadata: { ...existing.metadata, ...patch },
+      });
+    },
+
+    async listSessionsForDistillation(
+      criteria: DistillationCriteria,
+    ): Promise<readonly SessionId[]> {
+      if (criteria.kind === 'idle') {
+        return [...sessions.values()].filter((s) => s.status === 'idle').map((s) => s.id);
+      }
+      // session_ended | manual | rolling all target a specific session
+      return sessions.has(criteria.sessionId) ? [criteria.sessionId] : [];
+    },
+  };
+}
+
+describe('SessionStore port', () => {
+  it('admits a minimal in-memory implementation', async () => {
+    const store = buildFake();
+
+    const a = await store.findOrCreate('slack', 'slack:C1:1.0', 'default');
+    const aAgain = await store.findOrCreate('slack', 'slack:C1:1.0', 'default');
+    expect(aAgain.id).toBe(a.id);
+
+    const b = await store.findOrCreate('slack', 'slack:C2:2.0', 'default');
+    expect(b.id).not.toBe(a.id);
+
+    const userTurn = await store.recordTurn(a.id, {
+      authorRole: 'user',
+      contentText: 'hello',
+    });
+    expect(userTurn.seqNo).toBe(1n);
+
+    const agentTurn = await store.recordTurn(a.id, {
+      authorRole: 'agent',
+      contentText: 'hi back',
+      metadata: { usage: { input: 6, output: 7 } },
+    });
+    expect(agentTurn.seqNo).toBe(2n);
+
+    const recent = await store.getRecentTurns(a.id, 5);
+    expect(recent.map((t) => t.contentText)).toEqual(['hello', 'hi back']);
+
+    await store.updateStatus(a.id, 'idle');
+    await store.setMetadata(a.id, { synthetic_count: 0 });
+  });
+
+  it('listSessionsForDistillation handles all four trigger shapes', async () => {
+    const store = buildFake();
+    const a = await store.findOrCreate('cli', 'cli:1', 'default');
+    await store.updateStatus(a.id, 'idle');
+
+    const idle = await store.listSessionsForDistillation({
+      kind: 'idle',
+      idleSinceMin: 60,
+    });
+    expect(idle).toContain(a.id);
+
+    const ended = await store.listSessionsForDistillation({
+      kind: 'session_ended',
+      sessionId: a.id,
+    });
+    expect(ended).toEqual([a.id]);
+
+    const manual = await store.listSessionsForDistillation({
+      kind: 'manual',
+      sessionId: a.id,
+    });
+    expect(manual).toEqual([a.id]);
+
+    const rolling = await store.listSessionsForDistillation({
+      kind: 'rolling',
+      sessionId: a.id,
+      everyNTurns: 20,
+    });
+    expect(rolling).toEqual([a.id]);
+  });
+});

--- a/packages/core/src/ports/session-store.ts
+++ b/packages/core/src/ports/session-store.ts
@@ -1,0 +1,32 @@
+import type { SessionId, TenantId } from '../domain/ids.js';
+import type {
+  ChannelKind,
+  ChannelNativeRef,
+  DistillationCriteria,
+  Session,
+  SessionStatus,
+  Turn,
+  TurnInput,
+} from '../domain/session.js';
+
+// Episodic-memory port. Sessions and turns map directly onto the schema in
+// `docs/design/knowledge-store.md` §2.2. The store is canonical — agent
+// runners reconstruct prompts from it, distillation reads it, the channel
+// adapter writes synthetic turns into it.
+export interface SessionStore {
+  findOrCreate(
+    channelKind: ChannelKind,
+    channelNativeRef: ChannelNativeRef,
+    tenantId: TenantId,
+  ): Promise<Session>;
+
+  recordTurn(sessionId: SessionId, turn: TurnInput): Promise<Turn>;
+
+  getRecentTurns(sessionId: SessionId, limit: number): Promise<readonly Turn[]>;
+
+  updateStatus(sessionId: SessionId, status: SessionStatus): Promise<void>;
+
+  setMetadata(sessionId: SessionId, patch: Readonly<Record<string, unknown>>): Promise<void>;
+
+  listSessionsForDistillation(criteria: DistillationCriteria): Promise<readonly SessionId[]>;
+}


### PR DESCRIPTION
## Summary

Closes #40. Lifts the `SessionStore` port (ARCHITECTURE.md §4.3) and supporting session/turn domain types (`docs/design/knowledge-store.md` §2.2) into TypeScript code in `packages/core`. Type-only.

Building block toward #21 (minimal end-to-end Q&A flow). The concrete `PgvectorSessionStore` adapter follows in the next sub-issue.

## Files

`packages/core/src/domain/session.ts`:
- `ChannelKind` (open string), `ChannelNativeRef`
- `SessionStatus`, `AuthorRole`
- `Session`, `TurnInput`, `Turn`
- `DistillationCriteria` — discriminated union from design doc §5.1

`packages/core/src/ports/session-store.ts`:
- `SessionStore` — six methods per ARCHITECTURE.md §4.3

`packages/core/src/ports/session-store.test.ts` — inline conformance test exercising `findOrCreate` idempotency and all four `DistillationCriteria` branches.

## Notes for the next adapter author (continuing #36's conventions)

1. **Optional fields use `?`, not nullable.** With `exactOptionalPropertyTypes: true`, `TurnInput.authorRef?: …` means absent OR `undefined`. Postgres returns nullable JSONB columns as `null`; coerce `row.author_ref ?? undefined` when reading.
2. **`seqNo` and `distilledThroughSeqNo` are `bigint`** to match `BIGINT seq_no` in the schema. node-postgres returns BIGINT as `string` by default; convert.
3. **`participants: readonly unknown[]`** is intentionally permissive — channel adapters store whatever shape suits them (Slack user IDs as plain strings, Discord member objects, etc.).
4. **`SessionPolicy` is deferred.** The `SessionPolicy` interface in ARCHITECTURE.md §4.3 depends on `IncomingEvent`, which belongs to the unwritten `ChannelAdapter` port. Lifting them together is cleaner than a half-typed `SessionPolicy` here.

## Out of scope

- `PgvectorSessionStore` concrete adapter — next sub-issue
- `SessionPolicy` interface — lift with `ChannelAdapter` port
- Use-case orchestration — #21
- `ChannelAdapter` (Inbound + Outbound) ports — separate issue

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 54 passed | 6 skipped (2 new)
- [x] `pnpm lint` clean
- [x] `pnpm depcheck` passes (only pre-existing `apps/server/main.ts` orphan warning)

## Related

- Closes #40
- ARCHITECTURE.md §4.3 (port design closed in #8)
- Schema in #20 migration (`docs/design/knowledge-store.md` §2.2)
- Building block toward #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)