### PR TITLE
feat(adapter-store-pgvector): PgvectorSessionStore (#42)

### DIFF
--- a/packages/adapter-store-pgvector/src/__integration__/session-store.integration.test.ts
+++ b/packages/adapter-store-pgvector/src/__integration__/session-store.integration.test.ts
@@ -1,0 +1,164 @@
+import { Pool } from 'pg';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { runMigrations } from '../migrate/runner.js';
+import { PgvectorSessionStore } from '../session-store/pgvector-session-store.js';
+
+const integration = process.env.INTEGRATION === '1';
+
+describe.skipIf(!integration)('PgvectorSessionStore', () => {
+  let container: StartedTestContainer;
+  let pool: Pool;
+
+  beforeAll(async () => {
+    container = await new GenericContainer('pgvector/pgvector:pg17')
+      .withEnvironment({
+        POSTGRES_USER: 'agentry',
+        POSTGRES_PASSWORD: 'agentry',
+        POSTGRES_DB: 'agentry',
+      })
+      .withExposedPorts(5432)
+      .withWaitStrategy(Wait.forLogMessage(/database system is ready to accept connections/, 2))
+      .start();
+
+    const databaseUrl = `postgres://agentry:agentry@${container.getHost()}:${container.getMappedPort(5432)}/agentry`;
+    await runMigrations({ databaseUrl, embeddingDim: 1024 });
+    pool = new Pool({ connectionString: databaseUrl });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+    if (container) await container.stop();
+  });
+
+  it('findOrCreate is idempotent on (tenant, channel_kind, channel_native_ref) and touches last_active_at on conflict', async () => {
+    const store = new PgvectorSessionStore(pool);
+    const first = await store.findOrCreate('slack', 'slack:C1:1.0', 'default');
+    expect(first.tenantId).toBe('default');
+    expect(first.status).toBe('active');
+    expect(first.distilledThroughSeqNo).toBe(0n);
+
+    // Sleep briefly so last_active_at can move forward.
+    await new Promise((r) => setTimeout(r, 50));
+    const second = await store.findOrCreate('slack', 'slack:C1:1.0', 'default');
+    expect(second.id).toBe(first.id);
+    expect(second.lastActiveAt.getTime()).toBeGreaterThan(first.lastActiveAt.getTime());
+  });
+
+  it('recordTurn populates monotonic seq_no and stores all input fields', async () => {
+    const store = new PgvectorSessionStore(pool);
+    const session = await store.findOrCreate('slack', 'slack:C-recordTurn:1.0', 'default');
+
+    const t1 = await store.recordTurn(session.id, {
+      authorRole: 'user',
+      contentText: 'hello',
+    });
+    const t2 = await store.recordTurn(session.id, {
+      authorRole: 'agent',
+      contentText: 'hi back',
+      authorRef: { agent: 'claude' },
+      metadata: { usage: { input: 6, output: 7 } },
+    });
+
+    expect(t1.seqNo).toBeLessThan(t2.seqNo);
+    expect(t2.authorRef).toEqual({ agent: 'claude' });
+    expect(t2.metadata).toEqual({ usage: { input: 6, output: 7 } });
+    // Default for omitted optional fields.
+    expect(t1.authorRef).toBeUndefined();
+    expect(t1.contentExtra).toEqual({});
+  });
+
+  it('getRecentTurns returns chronological order (oldest of the window first), bounded by limit', async () => {
+    const store = new PgvectorSessionStore(pool);
+    const session = await store.findOrCreate('slack', 'slack:C-recent:1.0', 'default');
+    for (const text of ['a', 'b', 'c', 'd', 'e']) {
+      await store.recordTurn(session.id, {
+        authorRole: 'user',
+        contentText: text,
+      });
+    }
+
+    const last3 = await store.getRecentTurns(session.id, 3);
+    expect(last3.map((t) => t.contentText)).toEqual(['c', 'd', 'e']);
+  });
+
+  it('updateStatus transitions session.status', async () => {
+    const store = new PgvectorSessionStore(pool);
+    const session = await store.findOrCreate('slack', 'slack:C-status:1.0', 'default');
+    expect(session.status).toBe('active');
+
+    await store.updateStatus(session.id, 'idle');
+    const after = await pool.query<{ status: string }>(
+      'SELECT status FROM sessions WHERE id = $1',
+      [session.id],
+    );
+    expect(after.rows[0]?.status).toBe('idle');
+  });
+
+  it('setMetadata merges JSONB shallowly (preserve existing keys, overwrite overlaps)', async () => {
+    const store = new PgvectorSessionStore(pool);
+    const session = await store.findOrCreate('slack', 'slack:C-metadata:1.0', 'default');
+
+    await store.setMetadata(session.id, { feature_x: true, count: 1 });
+    await store.setMetadata(session.id, { count: 2, note: 'updated' });
+
+    const row = await pool.query<{ metadata: Record<string, unknown> }>(
+      'SELECT metadata FROM sessions WHERE id = $1',
+      [session.id],
+    );
+    expect(row.rows[0]?.metadata).toEqual({
+      feature_x: true,
+      count: 2,
+      note: 'updated',
+    });
+  });
+
+  it('listSessionsForDistillation handles all four trigger shapes', async () => {
+    const store = new PgvectorSessionStore(pool);
+    const idleSession = await store.findOrCreate('slack', 'slack:C-idle:1.0', 'default');
+    await store.updateStatus(idleSession.id, 'idle');
+    // Backdate last_active_at so the idle filter selects it.
+    await pool.query(
+      "UPDATE sessions SET last_active_at = now() - interval '120 minutes' WHERE id = $1",
+      [idleSession.id],
+    );
+
+    const idleResult = await store.listSessionsForDistillation({
+      kind: 'idle',
+      idleSinceMin: 60,
+    });
+    expect(idleResult).toContain(idleSession.id);
+
+    const activeSession = await store.findOrCreate('slack', 'slack:C-active:1.0', 'default');
+    const idleAgain = await store.listSessionsForDistillation({
+      kind: 'idle',
+      idleSinceMin: 60,
+    });
+    expect(idleAgain).not.toContain(activeSession.id);
+
+    const ended = await store.listSessionsForDistillation({
+      kind: 'session_ended',
+      sessionId: activeSession.id,
+    });
+    expect(ended).toEqual([activeSession.id]);
+
+    const manual = await store.listSessionsForDistillation({
+      kind: 'manual',
+      sessionId: activeSession.id,
+    });
+    expect(manual).toEqual([activeSession.id]);
+
+    const rolling = await store.listSessionsForDistillation({
+      kind: 'rolling',
+      sessionId: activeSession.id,
+      everyNTurns: 20,
+    });
+    expect(rolling).toEqual([activeSession.id]);
+
+    const missing = await store.listSessionsForDistillation({
+      kind: 'manual',
+      sessionId: '00000000-0000-0000-0000-000000000000',
+    });
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/adapter-store-pgvector/src/index.ts
+++ b/packages/adapter-store-pgvector/src/index.ts
@@ -1,2 +1,3 @@
 export type { MigrationOptions, MigrationsResult } from './migrate/runner.js';
 export { runMigrations } from './migrate/runner.js';
+export { PgvectorSessionStore } from './session-store/pgvector-session-store.js';

--- a/packages/adapter-store-pgvector/src/session-store/pgvector-session-store.ts
+++ b/packages/adapter-store-pgvector/src/session-store/pgvector-session-store.ts
@@ -1,0 +1,165 @@
+import type {
+  ChannelKind,
+  ChannelNativeRef,
+  DistillationCriteria,
+  Session,
+  SessionId,
+  SessionStatus,
+  SessionStore,
+  TenantId,
+  Turn,
+  TurnInput,
+} from '@agentry/core';
+import type { Pool } from 'pg';
+
+interface SessionRow {
+  id: string;
+  tenant_id: string;
+  channel_kind: string;
+  channel_native_ref: string;
+  started_at: Date;
+  last_active_at: Date;
+  status: string;
+  participants: unknown[];
+  metadata: Record<string, unknown>;
+  // pg returns BIGINT as string by default to avoid precision loss.
+  distilled_through_seq_no: string;
+}
+
+interface TurnRow {
+  id: string;
+  seq_no: string;
+  session_id: string;
+  author_role: string;
+  author_ref: Record<string, unknown> | null;
+  content_text: string;
+  content_extra: Record<string, unknown>;
+  created_at: Date;
+  metadata: Record<string, unknown>;
+}
+
+function mapSession(row: SessionRow): Session {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    channelKind: row.channel_kind,
+    channelNativeRef: row.channel_native_ref,
+    startedAt: row.started_at,
+    lastActiveAt: row.last_active_at,
+    status: row.status as SessionStatus,
+    participants: row.participants,
+    metadata: row.metadata,
+    distilledThroughSeqNo: BigInt(row.distilled_through_seq_no),
+  };
+}
+
+function mapTurn(row: TurnRow): Turn {
+  return {
+    id: row.id,
+    seqNo: BigInt(row.seq_no),
+    sessionId: row.session_id,
+    authorRole: row.author_role as Turn['authorRole'],
+    // null → undefined per the documented adapter convention.
+    ...(row.author_ref !== null ? { authorRef: row.author_ref } : {}),
+    contentText: row.content_text,
+    contentExtra: row.content_extra,
+    createdAt: row.created_at,
+    metadata: row.metadata,
+  };
+}
+
+export class PgvectorSessionStore implements SessionStore {
+  constructor(private readonly pool: Pool) {}
+
+  async findOrCreate(
+    channelKind: ChannelKind,
+    channelNativeRef: ChannelNativeRef,
+    tenantId: TenantId,
+  ): Promise<Session> {
+    // ON CONFLICT DO UPDATE acts as a touch: existing rows have
+    // last_active_at refreshed and returned, new rows inserted — both in
+    // a single round trip.
+    const result = await this.pool.query<SessionRow>(
+      `INSERT INTO sessions (
+         tenant_id, channel_kind, channel_native_ref,
+         started_at, last_active_at, status
+       )
+       VALUES ($1, $2, $3, now(), now(), 'active')
+       ON CONFLICT (tenant_id, channel_kind, channel_native_ref) DO UPDATE
+         SET last_active_at = now()
+       RETURNING *`,
+      [tenantId, channelKind, channelNativeRef],
+    );
+    const row = result.rows[0];
+    if (!row) {
+      throw new Error('findOrCreate returned no row — should be unreachable');
+    }
+    return mapSession(row);
+  }
+
+  async recordTurn(sessionId: SessionId, turn: TurnInput): Promise<Turn> {
+    const result = await this.pool.query<TurnRow>(
+      `INSERT INTO turns (
+         session_id, author_role, author_ref,
+         content_text, content_extra, metadata
+       )
+       VALUES ($1, $2, $3::jsonb, $4, $5::jsonb, $6::jsonb)
+       RETURNING *`,
+      [
+        sessionId,
+        turn.authorRole,
+        turn.authorRef ? JSON.stringify(turn.authorRef) : null,
+        turn.contentText,
+        JSON.stringify(turn.contentExtra ?? {}),
+        JSON.stringify(turn.metadata ?? {}),
+      ],
+    );
+    const row = result.rows[0];
+    if (!row) {
+      throw new Error('recordTurn returned no row — should be unreachable');
+    }
+    return mapTurn(row);
+  }
+
+  async getRecentTurns(sessionId: SessionId, limit: number): Promise<readonly Turn[]> {
+    const result = await this.pool.query<TurnRow>(
+      `SELECT * FROM turns
+       WHERE session_id = $1
+       ORDER BY seq_no DESC
+       LIMIT $2`,
+      [sessionId, limit],
+    );
+    // DESC + reverse → chronological (oldest of the limit-window first), so
+    // a use case can feed prior context to the agent without re-sorting.
+    return result.rows.reverse().map(mapTurn);
+  }
+
+  async updateStatus(sessionId: SessionId, status: SessionStatus): Promise<void> {
+    await this.pool.query('UPDATE sessions SET status = $1 WHERE id = $2', [status, sessionId]);
+  }
+
+  async setMetadata(sessionId: SessionId, patch: Readonly<Record<string, unknown>>): Promise<void> {
+    // JSONB || merges shallowly; overlapping keys take the right-side value.
+    await this.pool.query('UPDATE sessions SET metadata = metadata || $1::jsonb WHERE id = $2', [
+      JSON.stringify(patch),
+      sessionId,
+    ]);
+  }
+
+  async listSessionsForDistillation(criteria: DistillationCriteria): Promise<readonly SessionId[]> {
+    if (criteria.kind === 'idle') {
+      const result = await this.pool.query<{ id: string }>(
+        `SELECT id FROM sessions
+         WHERE status = 'idle'
+           AND last_active_at < now() - ($1 * interval '1 minute')`,
+        [criteria.idleSinceMin],
+      );
+      return result.rows.map((r) => r.id);
+    }
+    // session_ended | manual | rolling all target a single sessionId.
+    const result = await this.pool.query<{ id: string }>('SELECT id FROM sessions WHERE id = $1', [
+      criteria.sessionId,
+    ]);
+    return result.rows.map((r) => r.id);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #42. Concrete `SessionStore` adapter against the Postgres + pgvector schema (#20), conforming to the port lifted in #40. Second storage adapter class — sets the precedent the upcoming `PgvectorKnowledgeStore` will follow.

## Files

`packages/adapter-store-pgvector/src/session-store/pgvector-session-store.ts`:
- `PgvectorSessionStore` class. Constructor takes a `pg.Pool` (composition root manages pool lifecycle).
- All six `SessionStore` methods. Row mappers handle Postgres conventions: BIGINT (string) → bigint, nullable JSONB → property-absent under `exactOptionalPropertyTypes`, JSONB → parsed object/array.

`packages/adapter-store-pgvector/src/__integration__/session-store.integration.test.ts`:
- testcontainers `pgvector/pgvector:pg17`, applies migrations first.
- 6 tests covering: `findOrCreate` idempotency + last_active_at touch, `recordTurn` monotonic seq_no + field round-trip, `getRecentTurns` chronological window, `updateStatus`, JSONB metadata merge, all four `DistillationCriteria` shapes including the idle-window filter and a missing-session edge case.

## SQL choices

- **`findOrCreate`**: `INSERT ... ON CONFLICT (tenant_id, channel_kind, channel_native_ref) DO UPDATE SET last_active_at = now() RETURNING *`. Single round trip; treats find-as-touch since the only caller (`HandleIncomingMessage`) is processing an inbound event.
- **`setMetadata`**: `UPDATE sessions SET metadata = metadata || $1::jsonb`. Shallow merge — last write wins on overlapping keys.
- **`getRecentTurns`**: `ORDER BY seq_no DESC LIMIT N`, reversed in TS for chronological output.

## Out of scope

- `PgvectorKnowledgeStore` adapter — next sub-issue
- `SessionPolicy` (depends on `IncomingEvent` from unwritten ChannelAdapter port)
- Setting `participants` / `metadata` at session creation — no port method yet; adapter has no caller
- Active→idle auto-transition — use-case concern (`HandleIncomingMessage`)

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` 54 passed | 12 skipped
- [x] `INTEGRATION=1 pnpm --filter @agentry/adapter-store-pgvector test` 19 passed (6 new, 13 from #20 migrations test)
- [x] `pnpm lint` clean
- [x] `pnpm depcheck` passes (only pre-existing `apps/server/main.ts` orphan warning)

## Related

- Closes #42
- Implements port lifted in #40
- Reuses schema migrated by #20
- Building block toward #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)