### PR TITLE
feat(adapter-embedding-voyage): VoyageEmbeddingProvider (#45)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -354,13 +354,16 @@ interface KnowledgeIngestion {
 
 ```ts
 interface EmbeddingProvider {
-  readonly model: string;       // e.g., 'voyage-3'
+  readonly model: string;       // e.g., 'voyage-3.5'
   readonly dimension: number;   // declared, validated by KnowledgeStore on init
-  embed(texts: string[]): Promise<Float32Array[]>;
+  embed(texts: readonly string[]): Promise<readonly Float32Array[]>;
 }
 ```
 
-**Default**: Voyage `voyage-3`. Best-in-class retrieval quality at the time of writing.
+**Default**: Voyage `voyage-3.5` (1024 dim). Best-in-class retrieval quality and
+generous free tier (200M tokens shared across the voyage-3 family). Plain
+`voyage-3` was the original spec but is no longer in Voyage's documented model
+list; `voyage-3.5` is the supported successor at the same default dimension.
 Alternative `OpenAIEmbeddingProvider` (`text-embedding-3-large`, 3072 dim) ships
 as second adapter. Dimension mismatch between provider and store is a startup error.
 

--- a/packages/adapter-embedding-voyage/package.json
+++ b/packages/adapter-embedding-voyage/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@agentry/adapter-embedding-voyage",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@agentry/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.2"
+  }
+}

--- a/packages/adapter-embedding-voyage/src/__integration__/voyage-embedding-provider.integration.test.ts
+++ b/packages/adapter-embedding-voyage/src/__integration__/voyage-embedding-provider.integration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { VoyageEmbeddingProvider } from '../voyage-embedding-provider.js';
+
+const integration = process.env.INTEGRATION === '1';
+const apiKey = process.env.VOYAGE_API_KEY;
+
+describe.skipIf(!integration || !apiKey)('VoyageEmbeddingProvider (real API)', () => {
+  it('returns Float32Array of declared dimension for voyage-3.5', async () => {
+    const provider = new VoyageEmbeddingProvider({ apiKey: apiKey ?? '' });
+
+    const out = await provider.embed(['hello agentry']);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBeInstanceOf(Float32Array);
+    expect(out[0]?.length).toBe(provider.dimension);
+  }, 30_000);
+
+  it('preserves order across multiple inputs', async () => {
+    const provider = new VoyageEmbeddingProvider({ apiKey: apiKey ?? '' });
+
+    const out = await provider.embed(['cat', 'dog', 'bird']);
+
+    expect(out).toHaveLength(3);
+    // Distinct inputs should produce distinct vectors.
+    expect(out[0]?.[0]).not.toBe(out[1]?.[0]);
+    expect(out[1]?.[0]).not.toBe(out[2]?.[0]);
+  }, 30_000);
+});

--- a/packages/adapter-embedding-voyage/src/index.ts
+++ b/packages/adapter-embedding-voyage/src/index.ts
@@ -1,0 +1,5 @@
+export type {
+  VoyageEmbeddingProviderOptions,
+  VoyageModel,
+} from './voyage-embedding-provider.js';
+export { VoyageEmbeddingProvider } from './voyage-embedding-provider.js';

--- a/packages/adapter-embedding-voyage/src/voyage-embedding-provider.test.ts
+++ b/packages/adapter-embedding-voyage/src/voyage-embedding-provider.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VoyageEmbeddingProvider } from './voyage-embedding-provider.js';
+
+interface VoyageDataItem {
+  embedding: number[];
+  index: number;
+}
+
+function okResponse(data: VoyageDataItem[]): Response {
+  return new Response(
+    JSON.stringify({ object: 'list', data, model: 'voyage-3.5', usage: { total_tokens: 1 } }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+function errorResponse(
+  status: number,
+  body = 'error',
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(body, { status, headers });
+}
+
+function makeEmbedding(value: number, dim = 1024): number[] {
+  return Array.from({ length: dim }, () => value);
+}
+
+describe('VoyageEmbeddingProvider', () => {
+  describe('constructor + declarative properties', () => {
+    it('declares model and dimension for voyage-3.5 default', () => {
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k' });
+      expect(provider.model).toBe('voyage-3.5');
+      expect(provider.dimension).toBe(1024);
+    });
+  });
+
+  describe('embed (single batch)', () => {
+    it('returns Float32Array[] with correct dimension and order', async () => {
+      const fetchMock = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+        okResponse([
+          { index: 0, embedding: makeEmbedding(0.1) },
+          { index: 1, embedding: makeEmbedding(0.2) },
+        ]),
+      );
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+
+      const out = await provider.embed(['hello', 'world']);
+
+      expect(out).toHaveLength(2);
+      expect(out[0]).toBeInstanceOf(Float32Array);
+      expect(out[0]?.length).toBe(1024);
+      expect(out[0]?.[0]).toBeCloseTo(0.1);
+      expect(out[1]?.[0]).toBeCloseTo(0.2);
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      const [url, init] = fetchMock.mock.calls[0] ?? [];
+      expect(url).toBe('https://api.voyageai.com/v1/embeddings');
+      expect(init?.method).toBe('POST');
+      expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer k');
+      expect(JSON.parse(String(init?.body))).toEqual({
+        input: ['hello', 'world'],
+        model: 'voyage-3.5',
+      });
+    });
+
+    it('sorts response by index defensively', async () => {
+      const fetchMock = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+        okResponse([
+          { index: 1, embedding: makeEmbedding(0.2) },
+          { index: 0, embedding: makeEmbedding(0.1) },
+        ]),
+      );
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+
+      const out = await provider.embed(['a', 'b']);
+
+      expect(out[0]?.[0]).toBeCloseTo(0.1);
+      expect(out[1]?.[0]).toBeCloseTo(0.2);
+    });
+
+    it('returns [] for empty input without calling fetch', async () => {
+      const fetchMock = vi.fn<typeof globalThis.fetch>();
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+
+      const out = await provider.embed([]);
+
+      expect(out).toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('throws if response item count mismatches input count', async () => {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValue(okResponse([{ index: 0, embedding: makeEmbedding(0.1) }]));
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+
+      await expect(provider.embed(['a', 'b'])).rejects.toThrow(/1 embeddings for 2 inputs/);
+    });
+  });
+
+  describe('embed (multi-batch)', () => {
+    it('splits at batchSize and concatenates in input order', async () => {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValueOnce(
+          okResponse([
+            { index: 0, embedding: makeEmbedding(1) },
+            { index: 1, embedding: makeEmbedding(2) },
+          ]),
+        )
+        .mockResolvedValueOnce(
+          okResponse([
+            { index: 0, embedding: makeEmbedding(3) },
+            { index: 1, embedding: makeEmbedding(4) },
+          ]),
+        )
+        .mockResolvedValueOnce(okResponse([{ index: 0, embedding: makeEmbedding(5) }]));
+
+      const provider = new VoyageEmbeddingProvider({
+        apiKey: 'k',
+        fetch: fetchMock,
+        batchSize: 2,
+      });
+
+      const out = await provider.embed(['a', 'b', 'c', 'd', 'e']);
+
+      expect(out.map((v) => v[0])).toEqual([1, 2, 3, 4, 5]);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('retry behavior', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ['setTimeout'] });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('retries on 429 and succeeds', async () => {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValueOnce(errorResponse(429, 'rate limited'))
+        .mockResolvedValueOnce(okResponse([{ index: 0, embedding: makeEmbedding(0.1) }]));
+
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+      const promise = provider.embed(['hi']);
+      await vi.runAllTimersAsync();
+      const out = await promise;
+
+      expect(out).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on 500 and succeeds', async () => {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValueOnce(errorResponse(500))
+        .mockResolvedValueOnce(errorResponse(503))
+        .mockResolvedValueOnce(okResponse([{ index: 0, embedding: makeEmbedding(0.1) }]));
+
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+      const promise = provider.embed(['hi']);
+      await vi.runAllTimersAsync();
+      const out = await promise;
+
+      expect(out).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('throws after exhausting retries on 429', async () => {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValue(errorResponse(429, 'still rate limited'));
+
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+      const promise = provider.embed(['hi']);
+      const expectation = expect(promise).rejects.toThrow(/429/);
+      await vi.runAllTimersAsync();
+      await expectation;
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not retry on 4xx other than 429', async () => {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValue(errorResponse(401, 'unauthorized'));
+
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'bad', fetch: fetchMock });
+
+      await expect(provider.embed(['hi'])).rejects.toThrow(/401/);
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it('retries on network error', async () => {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce(okResponse([{ index: 0, embedding: makeEmbedding(0.1) }]));
+
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+      const promise = provider.embed(['hi']);
+      await vi.runAllTimersAsync();
+      const out = await promise;
+
+      expect(out).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws original error after exhausting retries on network error', async () => {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockRejectedValue(new Error('ECONNRESET'));
+
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+      const promise = provider.embed(['hi']);
+      const expectation = expect(promise).rejects.toThrow('ECONNRESET');
+      await vi.runAllTimersAsync();
+      await expectation;
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('honors Retry-After header (seconds) on 429', async () => {
+      const fetchMock = vi
+        .fn<typeof globalThis.fetch>()
+        .mockResolvedValueOnce(errorResponse(429, 'rate limited', { 'Retry-After': '5' }))
+        .mockResolvedValueOnce(okResponse([{ index: 0, embedding: makeEmbedding(0.1) }]));
+
+      const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
+      const promise = provider.embed(['hi']);
+
+      // After the first response, the adapter sleeps 5000ms (Retry-After), not
+      // the 200ms exponential default. Advance by 200ms first — the second
+      // fetch must NOT have fired yet.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      const out = await promise;
+      expect(out).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/adapter-embedding-voyage/src/voyage-embedding-provider.ts
+++ b/packages/adapter-embedding-voyage/src/voyage-embedding-provider.ts
@@ -1,0 +1,145 @@
+import type { EmbeddingProvider } from '@agentry/core';
+
+export type VoyageModel = 'voyage-3.5';
+
+const MODEL_DIMENSIONS: Record<VoyageModel, number> = {
+  'voyage-3.5': 1024,
+};
+
+const VOYAGE_ENDPOINT = 'https://api.voyageai.com/v1/embeddings';
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BATCH_SIZE = 128;
+const RETRY_AFTER_CAP_MS = 30_000;
+
+export interface VoyageEmbeddingProviderOptions {
+  readonly apiKey: string;
+  readonly model?: VoyageModel;
+  readonly fetch?: typeof globalThis.fetch;
+  readonly maxRetries?: number;
+  readonly batchSize?: number;
+}
+
+interface VoyageResponseItem {
+  readonly embedding: readonly number[];
+  readonly index: number;
+}
+
+interface VoyageResponse {
+  readonly data: readonly VoyageResponseItem[];
+}
+
+export class VoyageEmbeddingProvider implements EmbeddingProvider {
+  readonly model: VoyageModel;
+  readonly dimension: number;
+
+  private readonly apiKey: string;
+  private readonly fetchFn: typeof globalThis.fetch;
+  private readonly maxRetries: number;
+  private readonly batchSize: number;
+
+  constructor(options: VoyageEmbeddingProviderOptions) {
+    this.model = options.model ?? 'voyage-3.5';
+    this.dimension = MODEL_DIMENSIONS[this.model];
+    this.apiKey = options.apiKey;
+    this.fetchFn = options.fetch ?? globalThis.fetch;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+  }
+
+  async embed(texts: readonly string[]): Promise<readonly Float32Array[]> {
+    if (texts.length === 0) return [];
+
+    const results: Float32Array[] = new Array(texts.length);
+    for (let start = 0; start < texts.length; start += this.batchSize) {
+      const batch = texts.slice(start, start + this.batchSize);
+      const batchResult = await this.embedBatch(batch);
+      for (let i = 0; i < batchResult.length; i++) {
+        const vec = batchResult[i];
+        if (vec === undefined) {
+          throw new Error(
+            `Voyage API returned ${batchResult.length} embeddings for ${batch.length} inputs at batch starting ${start}`,
+          );
+        }
+        results[start + i] = vec;
+      }
+    }
+    return results;
+  }
+
+  private async embedBatch(texts: readonly string[]): Promise<Float32Array[]> {
+    for (let attempt = 0; attempt < this.maxRetries; attempt++) {
+      const isLastAttempt = attempt === this.maxRetries - 1;
+
+      let response: Response;
+      try {
+        response = await this.fetchFn(VOYAGE_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${this.apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ input: texts, model: this.model }),
+        });
+      } catch (err) {
+        if (isLastAttempt) throw err;
+        await sleep(exponentialBackoffMs(attempt));
+        continue;
+      }
+
+      if (response.ok) {
+        const json = (await response.json()) as VoyageResponse;
+        // Voyage's contract says `index` matches input order, but sort defensively
+        // — the EmbeddingProvider port (#44) pins order preservation, and the
+        // cost is O(n log n) on a small batch.
+        const sorted = [...json.data].sort((a, b) => a.index - b.index);
+        if (sorted.length !== texts.length) {
+          throw new Error(
+            `Voyage API returned ${sorted.length} embeddings for ${texts.length} inputs`,
+          );
+        }
+        return sorted.map((item) => Float32Array.from(item.embedding));
+      }
+
+      const retryable = response.status === 429 || response.status >= 500;
+      if (retryable && !isLastAttempt) {
+        const waitMs =
+          response.status === 429
+            ? (parseRetryAfter(response.headers.get('retry-after')) ??
+              exponentialBackoffMs(attempt))
+            : exponentialBackoffMs(attempt);
+        await sleep(waitMs);
+        continue;
+      }
+
+      // Body may contain useful diagnostics (e.g. token-limit-exceeded), but
+      // never includes the apiKey since we never echo it back.
+      const body = await response.text().catch(() => '');
+      throw new Error(`Voyage API ${response.status}: ${body}`);
+    }
+    // Loop either returns or throws on every iteration; this is unreachable.
+    throw new Error('embedBatch retry loop exited unexpectedly');
+  }
+}
+
+function exponentialBackoffMs(attempt: number): number {
+  return 2 ** attempt * 200;
+}
+
+function parseRetryAfter(header: string | null): number | null {
+  if (!header) return null;
+  const seconds = Number(header);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.min(seconds * 1000, RETRY_AFTER_CAP_MS);
+  }
+  // HTTP-date form per RFC 7231.
+  const dateMs = Date.parse(header);
+  if (Number.isFinite(dateMs)) {
+    const delta = dateMs - Date.now();
+    if (delta > 0) return Math.min(delta, RETRY_AFTER_CAP_MS);
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/adapter-embedding-voyage/tsconfig.json
+++ b/packages/adapter-embedding-voyage/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules"],
+  "references": [{ "path": "../core" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,16 @@ importers:
         specifier: ^24.0.0
         version: 24.12.2
 
+  packages/adapter-embedding-voyage:
+    dependencies:
+      '@agentry/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
+
   packages/adapter-jobrunner-memory:
     dependencies:
       '@agentry/core':

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
       "@agentry/testing": ["packages/testing/src/index.ts"],
       "@agentry/adapter-runner-claude-cli": ["packages/adapter-runner-claude-cli/src/index.ts"],
       "@agentry/adapter-jobrunner-memory": ["packages/adapter-jobrunner-memory/src/index.ts"],
-      "@agentry/adapter-store-pgvector": ["packages/adapter-store-pgvector/src/index.ts"]
+      "@agentry/adapter-store-pgvector": ["packages/adapter-store-pgvector/src/index.ts"],
+      "@agentry/adapter-embedding-voyage": ["packages/adapter-embedding-voyage/src/index.ts"]
     }
   },
   "files": [],
@@ -18,6 +19,7 @@
     { "path": "packages/adapter-runner-claude-cli" },
     { "path": "packages/adapter-jobrunner-memory" },
     { "path": "packages/adapter-store-pgvector" },
+    { "path": "packages/adapter-embedding-voyage" },
     { "path": "apps/server" },
     { "path": "apps/cli" }
   ]


### PR DESCRIPTION
## Summary

Concrete `EmbeddingProvider` adapter calling Voyage's `/v1/embeddings`, conforming to the port lifted in #44 (PR #46).

**Default model: `voyage-3.5`** (1024 dim) — *not* `voyage-3` as originally specified in ARCHITECTURE.md §4.6 / closed design issue #23. Voyage's current published model list (https://docs.voyageai.com/reference/inference) no longer includes plain `voyage-3`; `voyage-3.5` is the supported successor at the same default dimension and shares the same 200M-token free tier across the voyage-3 family. ARCHITECTURE.md §4.6 updated to record this.

## What changed

- New package `@agentry/adapter-embedding-voyage` (workspace dep on `@agentry/core` only).
- `src/voyage-embedding-provider.ts` — class implementing `EmbeddingProvider`.
  - Constructor: `{ apiKey, model?, fetch?, maxRetries?, batchSize? }`. `maxRetries` (default 3) and `batchSize` (default 128) are beyond the issue spec; added for unit-test ergonomics.
  - Batching: `embed` splits at `batchSize`, calls `embedBatch` per chunk, reassembles into input order.
  - Retry: 429 / 5xx / network errors with exponential backoff (200/400/800ms). 429 honors the `Retry-After` header (seconds or HTTP-date) when present, capped to 30s. 4xx other than 429 fail fast.
  - Order preservation: response `data[].index` is sorted defensively before mapping, even though Voyage promises input-order — matches the contract pinned by #44's conformance test.
  - Error messages include status + body but never the API key.
- `src/voyage-embedding-provider.test.ts` — 13 unit tests with mocked `fetch` and `vi.useFakeTimers`. Covers happy path, sort defense, multi-batch, mismatch, all retry scenarios (429, 5xx, network, exhaustion, 401 fail-fast, Retry-After honor).
- `src/__integration__/voyage-embedding-provider.integration.test.ts` — gated on `INTEGRATION=1` AND `VOYAGE_API_KEY`. Verifies real Voyage 1024-dim response and order preservation.
- `tsconfig.json` (root) + `tsconfig.json` (package) — workspace path mapping + project reference.

## Out of scope (filed in issue body)

- Other Voyage models (`voyage-3-large`, `voyage-4-large`, etc.) — add when needed.
- `output_dimension` / `input_type` / `output_dtype` — port doesn't carry hints; revisit when retrieval-quality tuning matters.
- OpenAI adapter — separate issue.
- Caching — composition concern.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (biome)
- [x] `pnpm test` — 68 passed, 14 skipped (integration gated)
- [x] `pnpm depcheck` — no new violations
- [ ] Manual verification with real `VOYAGE_API_KEY` (skipped in CI by design; user can run `INTEGRATION=1 VOYAGE_API_KEY=… pnpm --filter @agentry/adapter-embedding-voyage test` locally)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)