### PR TITLE
feat(adapter-store-pgvector): PgvectorKnowledgeStore (#48)

### DIFF
--- a/packages/adapter-embedding-voyage/src/voyage-embedding-provider.test.ts
+++ b/packages/adapter-embedding-voyage/src/voyage-embedding-provider.test.ts
@@ -210,9 +210,7 @@ describe('VoyageEmbeddingProvider', () => {
     });
 
     it('throws original error after exhausting retries on network error', async () => {
-      const fetchMock = vi
-        .fn<typeof globalThis.fetch>()
-        .mockRejectedValue(new Error('ECONNRESET'));
+      const fetchMock = vi.fn<typeof globalThis.fetch>().mockRejectedValue(new Error('ECONNRESET'));
 
       const provider = new VoyageEmbeddingProvider({ apiKey: 'k', fetch: fetchMock });
       const promise = provider.embed(['hi']);

--- a/packages/adapter-store-pgvector/src/__integration__/knowledge-store.integration.test.ts
+++ b/packages/adapter-store-pgvector/src/__integration__/knowledge-store.integration.test.ts
@@ -1,0 +1,404 @@
+import type { EmbeddingProvider } from '@agentry/core';
+import { Pool } from 'pg';
+import { GenericContainer, type StartedTestContainer, Wait } from 'testcontainers';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { PgvectorKnowledgeStore } from '../knowledge-store/pgvector-knowledge-store.js';
+import { runMigrations } from '../migrate/runner.js';
+
+const integration = process.env.INTEGRATION === '1';
+
+class DeterministicFakeEmbeddings implements EmbeddingProvider {
+  readonly model = 'fake-1024';
+  readonly dimension = 1024;
+  async embed(texts: readonly string[]): Promise<readonly Float32Array[]> {
+    return texts.map((text) => {
+      const v = new Float32Array(1024);
+      let h = 0;
+      for (let i = 0; i < text.length; i++) h = (h * 31 + text.charCodeAt(i)) | 0;
+      // Spread per-text hash across the vector so cosine distance varies
+      // per input — keeps retrieve ordering deterministic but distinct.
+      v[0] = h / 1e9;
+      v[1] = text.length / 100;
+      v[2] = (text.charCodeAt(0) || 0) / 255;
+      return v;
+    });
+  }
+}
+
+describe.skipIf(!integration)('PgvectorKnowledgeStore', () => {
+  let container: StartedTestContainer;
+  let pool: Pool;
+  let store: PgvectorKnowledgeStore;
+
+  beforeAll(async () => {
+    container = await new GenericContainer('pgvector/pgvector:pg17')
+      .withEnvironment({
+        POSTGRES_USER: 'agentry',
+        POSTGRES_PASSWORD: 'agentry',
+        POSTGRES_DB: 'agentry',
+      })
+      .withExposedPorts(5432)
+      .withWaitStrategy(Wait.forLogMessage(/database system is ready to accept connections/, 2))
+      .start();
+
+    const databaseUrl = `postgres://agentry:agentry@${container.getHost()}:${container.getMappedPort(5432)}/agentry`;
+    await runMigrations({ databaseUrl, embeddingDim: 1024 });
+    pool = new Pool({ connectionString: databaseUrl });
+    store = new PgvectorKnowledgeStore({ pool, embeddings: new DeterministicFakeEmbeddings() });
+  }, 120_000);
+
+  afterAll(async () => {
+    if (pool) await pool.end();
+    if (container) await container.stop();
+  });
+
+  describe('recordSource', () => {
+    it('is idempotent on (tenantId, sourceKind, locator) and merges metadata', async () => {
+      const a = await store.recordSource({
+        tenantId: 'default',
+        sourceKind: 'github',
+        locator: 'org/repo#README',
+        metadata: { branch: 'main' },
+      });
+      const b = await store.recordSource({
+        tenantId: 'default',
+        sourceKind: 'github',
+        locator: 'org/repo#README',
+        metadata: { commit: 'abc' },
+      });
+      expect(b).toBe(a);
+
+      const row = (await pool.query('SELECT metadata FROM source_refs WHERE id = $1', [a])).rows[0];
+      expect(row.metadata).toEqual({ branch: 'main', commit: 'abc' });
+    });
+  });
+
+  describe('upsertItem', () => {
+    it('inserts a new item with computed snap and session provenance', async () => {
+      const id = await store.upsertItem({
+        tenantId: 'default',
+        sourceType: 'user_session',
+        kind: 'fact',
+        text: 'The sky is blue.',
+        extractorSelfRating: 0.8,
+        derivedFrom: {
+          kind: 'session',
+          sessionId: null,
+          turnRange: null,
+          provenanceLostAt: null,
+        },
+        extractorVersion: 'test-1',
+      });
+
+      const row = (
+        await pool.query(
+          'SELECT n_confirmations, confidence_snapshot, derived_from_kind FROM knowledge_items WHERE id = $1',
+          [id],
+        )
+      ).rows[0];
+      expect(row.n_confirmations).toBe(1);
+      // 0.8 * 0.6 + 0.2 = 0.68
+      expect(Number(row.confidence_snapshot)).toBeCloseTo(0.68, 2);
+      expect(row.derived_from_kind).toBe('session');
+    });
+
+    it('persists non-null turnRange when referenced turns exist', async () => {
+      const sessionRes = await pool.query<{ id: string }>(
+        `INSERT INTO sessions (tenant_id, channel_kind, channel_native_ref, started_at, last_active_at, status)
+         VALUES ('default', 'cli', 'turn-prov-test', now(), now(), 'active')
+         RETURNING id`,
+      );
+      const sessionId = sessionRes.rows[0]?.id ?? '';
+      const turnRes = await pool.query<{ seq_no: string }>(
+        `INSERT INTO turns (session_id, author_role, content_text)
+         VALUES ($1, 'user', 'first'), ($1, 'agent', 'second')
+         RETURNING seq_no`,
+        [sessionId],
+      );
+      const lo = BigInt(turnRes.rows[0]?.seq_no ?? '0');
+      const hi = BigInt(turnRes.rows[1]?.seq_no ?? '0');
+
+      const id = await store.upsertItem({
+        tenantId: 'default',
+        sourceType: 'user_session',
+        kind: 'fact',
+        text: `provenance round-trip ${sessionId}`,
+        extractorSelfRating: 0.5,
+        derivedFrom: { kind: 'session', sessionId, turnRange: [lo, hi], provenanceLostAt: null },
+        extractorVersion: 'test-1',
+      });
+      const row = (
+        await pool.query(
+          'SELECT derived_from_session, derived_from_turn_lo, derived_from_turn_hi FROM knowledge_items WHERE id = $1',
+          [id],
+        )
+      ).rows[0];
+      expect(row.derived_from_session).toBe(sessionId);
+      expect(BigInt(row.derived_from_turn_lo)).toBe(lo);
+      expect(BigInt(row.derived_from_turn_hi)).toBe(hi);
+    });
+
+    it('on canonical-hash conflict bumps n_confirmations and recomputes snap', async () => {
+      const baseInput = {
+        tenantId: 'default',
+        sourceType: 'user_session' as const,
+        kind: 'fact' as const,
+        derivedFrom: {
+          kind: 'session' as const,
+          sessionId: null,
+          turnRange: null,
+          provenanceLostAt: null,
+        },
+        extractorVersion: 'test-1',
+      };
+      const idA = await store.upsertItem({
+        ...baseInput,
+        text: 'Pluto is a planet',
+        extractorSelfRating: 0.7,
+      });
+      const idB = await store.upsertItem({
+        ...baseInput,
+        text: 'pluto is a planet.', // canonicalizes to the same key
+        extractorSelfRating: 0.5,
+      });
+      expect(idB).toBe(idA);
+
+      const row = (
+        await pool.query(
+          'SELECT n_confirmations, confidence_snapshot FROM knowledge_items WHERE id = $1',
+          [idA],
+        )
+      ).rows[0];
+      expect(row.n_confirmations).toBe(2);
+      // EXCLUDED rating = 0.5; boost(2) = 0.5 + 0.1 * (n_old=1) = 0.6
+      // snap = 0.5 * 0.6 + 0.6 * 0.4 = 0.54
+      expect(Number(row.confidence_snapshot)).toBeCloseTo(0.54, 2);
+    });
+
+    it('persists external provenance correctly', async () => {
+      const sourceId = await store.recordSource({
+        tenantId: 'default',
+        sourceKind: 'web',
+        locator: 'https://example.com/article',
+      });
+      const id = await store.upsertItem({
+        tenantId: 'default',
+        sourceType: 'external_sync',
+        kind: 'fact',
+        text: 'External fact body',
+        extractorSelfRating: 0.9,
+        derivedFrom: {
+          kind: 'external',
+          sourceId,
+          locator: 'https://example.com/article#para1',
+        },
+        extractorVersion: 'test-1',
+      });
+
+      const row = (
+        await pool.query(
+          'SELECT derived_from_kind, derived_from_source, derived_from_locator FROM knowledge_items WHERE id = $1',
+          [id],
+        )
+      ).rows[0];
+      expect(row.derived_from_kind).toBe('external');
+      expect(row.derived_from_source).toBe(sourceId);
+      expect(row.derived_from_locator).toBe('https://example.com/article#para1');
+    });
+  });
+
+  describe('retrieve', () => {
+    const tenantId = 'default';
+    const baseInput = {
+      tenantId,
+      sourceType: 'project_seed' as const,
+      kind: 'fact' as const,
+      derivedFrom: {
+        kind: 'session' as const,
+        sessionId: null,
+        turnRange: null,
+        provenanceLostAt: null,
+      },
+      extractorVersion: 'test-1',
+    };
+
+    beforeAll(async () => {
+      // Use distinct external_ids to avoid colliding with earlier upsert tests.
+      await store.upsertItem({
+        ...baseInput,
+        externalId: 'rt-1',
+        text: 'apple is a fruit',
+        extractorSelfRating: 0.9,
+      });
+      await store.upsertItem({
+        ...baseInput,
+        externalId: 'rt-2',
+        kind: 'decision',
+        text: 'we choose typescript',
+        extractorSelfRating: 0.5,
+      });
+      await store.upsertItem({
+        ...baseInput,
+        externalId: 'rt-3',
+        sourceType: 'user_session',
+        text: 'banana is yellow',
+        extractorSelfRating: 0.7,
+      });
+    });
+
+    it('returns topK results ordered by score desc', async () => {
+      const result = await store.retrieve({
+        tenantId,
+        text: 'apple is a fruit',
+        mode: 'semantic',
+        topK: 2,
+      });
+      expect(result.items).toHaveLength(2);
+      // Score is 1 - cosine_distance; descending order.
+      expect(result.items[0]?.score).toBeGreaterThanOrEqual(result.items[1]?.score ?? 0);
+      expect(result.items[0]?.confidenceFinal).toBe(result.items[0]?.item.confidenceSnapshot);
+    });
+
+    it('filters by sourceTypes', async () => {
+      const result = await store.retrieve({
+        tenantId,
+        text: 'anything',
+        mode: 'semantic',
+        topK: 10,
+        filters: { sourceTypes: ['user_session'] },
+      });
+      expect(result.items.every((r) => r.item.sourceType === 'user_session')).toBe(true);
+    });
+
+    it('filters by kinds', async () => {
+      const result = await store.retrieve({
+        tenantId,
+        text: 'anything',
+        mode: 'semantic',
+        topK: 10,
+        filters: { kinds: ['decision'] },
+      });
+      expect(result.items.every((r) => r.item.kind === 'decision')).toBe(true);
+    });
+
+    it('filters by minConfidence', async () => {
+      const result = await store.retrieve({
+        tenantId,
+        text: 'anything',
+        mode: 'semantic',
+        topK: 10,
+        filters: { minConfidence: 0.7 },
+      });
+      expect(result.items.every((r) => r.item.confidenceSnapshot >= 0.7)).toBe(true);
+    });
+  });
+
+  describe('deleteBySource', () => {
+    it('removes only items derived from that source', async () => {
+      const sourceId = await store.recordSource({
+        tenantId: 'default',
+        sourceKind: 'web',
+        locator: 'https://delete-me.example/page',
+      });
+      const targetId = await store.upsertItem({
+        tenantId: 'default',
+        sourceType: 'external_sync',
+        kind: 'fact',
+        text: 'Doomed external item',
+        extractorSelfRating: 0.5,
+        derivedFrom: { kind: 'external', sourceId, locator: 'https://delete-me.example/page#x' },
+        extractorVersion: 'test-1',
+      });
+      const survivorId = await store.upsertItem({
+        tenantId: 'default',
+        sourceType: 'user_session',
+        kind: 'fact',
+        text: 'Survivor item',
+        extractorSelfRating: 0.5,
+        derivedFrom: { kind: 'session', sessionId: null, turnRange: null, provenanceLostAt: null },
+        extractorVersion: 'test-1',
+      });
+
+      await store.deleteBySource(sourceId);
+
+      const target = await pool.query('SELECT id FROM knowledge_items WHERE id = $1', [targetId]);
+      const survivor = await pool.query('SELECT id FROM knowledge_items WHERE id = $1', [
+        survivorId,
+      ]);
+      expect(target.rowCount).toBe(0);
+      expect(survivor.rowCount).toBe(1);
+    });
+  });
+
+  describe('deleteByExternalId', () => {
+    it('removes only project_seed items with the given externalId; ignores other source_types', async () => {
+      // The schema's `(tenant_id, external_id) UNIQUE WHERE external_id IS NOT
+      // NULL` index makes externalId globally unique per tenant — collision
+      // across source_types isn't structurally possible. The hard-coded
+      // `source_type = 'project_seed'` filter is defense-in-depth: should the
+      // schema ever loosen, a stale user-data externalId still can't wipe
+      // distilled knowledge. Verify by inserting a non-matching user_session
+      // row alongside, and checking only the project_seed row is deleted.
+      const seedId = await store.upsertItem({
+        tenantId: 'default',
+        externalId: 'doomed-seed',
+        sourceType: 'project_seed',
+        kind: 'fact',
+        text: 'project seed fact for doomed-seed',
+        extractorSelfRating: 0.5,
+        derivedFrom: { kind: 'session', sessionId: null, turnRange: null, provenanceLostAt: null },
+        extractorVersion: 'test-1',
+      });
+      const survivorId = await store.upsertItem({
+        tenantId: 'default',
+        sourceType: 'user_session',
+        kind: 'fact',
+        text: 'unrelated user-session fact that must survive',
+        extractorSelfRating: 0.5,
+        derivedFrom: { kind: 'session', sessionId: null, turnRange: null, provenanceLostAt: null },
+        extractorVersion: 'test-1',
+      });
+
+      await store.deleteByExternalId('default', 'doomed-seed');
+
+      const seed = await pool.query('SELECT id FROM knowledge_items WHERE id = $1', [seedId]);
+      const survivor = await pool.query('SELECT id FROM knowledge_items WHERE id = $1', [
+        survivorId,
+      ]);
+      expect(seed.rowCount).toBe(0);
+      expect(survivor.rowCount).toBe(1);
+    });
+  });
+
+  describe('listByTenant', () => {
+    it('paginates across more than one page (>200 rows)', async () => {
+      // Create a fresh tenant so this test's row count is independent of
+      // earlier tests' inserts.
+      await pool.query("INSERT INTO tenants (id, display_name) VALUES ('list-test', 'List Test')");
+
+      const target = 250;
+      for (let i = 0; i < target; i++) {
+        await store.upsertItem({
+          tenantId: 'list-test',
+          sourceType: 'project_seed',
+          kind: 'fact',
+          text: `paged item ${i}`,
+          extractorSelfRating: 0.5,
+          derivedFrom: {
+            kind: 'session',
+            sessionId: null,
+            turnRange: null,
+            provenanceLostAt: null,
+          },
+          extractorVersion: 'test-1',
+        });
+      }
+
+      let count = 0;
+      for await (const _ of store.listByTenant('list-test', {})) {
+        count += 1;
+      }
+      expect(count).toBe(target);
+    }, 60_000);
+  });
+});

--- a/packages/adapter-store-pgvector/src/index.ts
+++ b/packages/adapter-store-pgvector/src/index.ts
@@ -1,3 +1,5 @@
+export type { PgvectorKnowledgeStoreOptions } from './knowledge-store/pgvector-knowledge-store.js';
+export { PgvectorKnowledgeStore } from './knowledge-store/pgvector-knowledge-store.js';
 export type { MigrationOptions, MigrationsResult } from './migrate/runner.js';
 export { runMigrations } from './migrate/runner.js';
 export { PgvectorSessionStore } from './session-store/pgvector-session-store.js';

--- a/packages/adapter-store-pgvector/src/knowledge-store/canonicalize.test.ts
+++ b/packages/adapter-store-pgvector/src/knowledge-store/canonicalize.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { canonicalHash, canonicalize } from './canonicalize.js';
+
+describe('canonicalize', () => {
+  it('lowercases', () => {
+    expect(canonicalize('Hello World')).toBe('hello world');
+  });
+
+  it('collapses internal whitespace', () => {
+    expect(canonicalize('a  b\t\nc')).toBe('a b c');
+  });
+
+  it('strips trailing punctuation', () => {
+    expect(canonicalize('agentry rocks!')).toBe('agentry rocks');
+    expect(canonicalize('really??')).toBe('really');
+    expect(canonicalize('end.')).toBe('end');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(canonicalize('  hello  ')).toBe('hello');
+  });
+
+  it('preserves internal punctuation', () => {
+    expect(canonicalize("it's fine, really.")).toBe("it's fine, really");
+  });
+});
+
+describe('canonicalHash', () => {
+  it('returns 64-char hex SHA-256', () => {
+    const h = canonicalHash('hello');
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic', () => {
+    expect(canonicalHash('hello')).toBe(canonicalHash('hello'));
+  });
+
+  it('collapses canonicalization-equivalent inputs', () => {
+    expect(canonicalHash('Hello World!')).toBe(canonicalHash('hello   world'));
+  });
+
+  it('distinguishes semantically different inputs', () => {
+    expect(canonicalHash('hello')).not.toBe(canonicalHash('world'));
+  });
+});

--- a/packages/adapter-store-pgvector/src/knowledge-store/canonicalize.ts
+++ b/packages/adapter-store-pgvector/src/knowledge-store/canonicalize.ts
@@ -1,0 +1,16 @@
+import { createHash } from 'node:crypto';
+
+// Per knowledge-store design §3: lowercase, collapse whitespace, strip
+// trailing punctuation. Used as the dedup key (hashed into SHA-256), not for
+// display — preserve raw `text` separately.
+export function canonicalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .replace(/[.,;:!?]+$/, '')
+    .trim();
+}
+
+export function canonicalHash(text: string): string {
+  return createHash('sha256').update(canonicalize(text)).digest('hex');
+}

--- a/packages/adapter-store-pgvector/src/knowledge-store/pgvector-knowledge-store.ts
+++ b/packages/adapter-store-pgvector/src/knowledge-store/pgvector-knowledge-store.ts
@@ -1,0 +1,334 @@
+import type {
+  EmbeddingProvider,
+  ItemFilter,
+  KnowledgeId,
+  KnowledgeItem,
+  KnowledgeItemInput,
+  KnowledgeKind,
+  KnowledgeStore,
+  ProvenanceRef,
+  RetrievalQuery,
+  RetrievalResult,
+  RetrievedKnowledgeItem,
+  SourceId,
+  SourceRefInput,
+  SourceType,
+  TenantId,
+} from '@agentry/core';
+import type { Pool } from 'pg';
+import { canonicalHash } from './canonicalize.js';
+
+const LIST_PAGE_SIZE = 200;
+
+interface SourceRow {
+  id: string;
+}
+
+interface KnowledgeRow {
+  id: string;
+  tenant_id: string;
+  external_id: string | null;
+  source_type: string;
+  kind: string;
+  text: string;
+  text_canonical_hash: string;
+  // pg returns NUMERIC as string by default to avoid precision loss.
+  extractor_self_rating: string;
+  n_confirmations: number;
+  last_referenced_at: Date;
+  confidence_snapshot: string;
+  derived_from_kind: 'session' | 'external';
+  derived_from_session: string | null;
+  derived_from_turn_lo: string | null;
+  derived_from_turn_hi: string | null;
+  derived_from_source: string | null;
+  derived_from_locator: string | null;
+  extractor_version: string;
+  created_at: Date;
+  updated_at: Date;
+  metadata: Record<string, unknown>;
+}
+
+interface RetrievedRow extends KnowledgeRow {
+  // Cosine similarity (1 - distance), surfaced via SELECT expression.
+  score: string;
+}
+
+export interface PgvectorKnowledgeStoreOptions {
+  readonly pool: Pool;
+  readonly embeddings: EmbeddingProvider;
+}
+
+export class PgvectorKnowledgeStore implements KnowledgeStore {
+  private readonly pool: Pool;
+  private readonly embeddings: EmbeddingProvider;
+
+  constructor(options: PgvectorKnowledgeStoreOptions) {
+    this.pool = options.pool;
+    this.embeddings = options.embeddings;
+  }
+
+  async recordSource(ref: SourceRefInput): Promise<SourceId> {
+    const result = await this.pool.query<SourceRow>(
+      `INSERT INTO source_refs (tenant_id, source_kind, locator, metadata)
+       VALUES ($1, $2, $3, $4::jsonb)
+       ON CONFLICT (tenant_id, source_kind, locator) DO UPDATE
+         SET metadata = source_refs.metadata || $4::jsonb
+       RETURNING id`,
+      [ref.tenantId, ref.sourceKind, ref.locator, JSON.stringify(ref.metadata ?? {})],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error('recordSource returned no row — should be unreachable');
+    return row.id;
+  }
+
+  async upsertItem(item: KnowledgeItemInput): Promise<KnowledgeId> {
+    const hash = canonicalHash(item.text);
+    const [embedding] = await this.embeddings.embed([item.text]);
+    if (!embedding) {
+      throw new Error('EmbeddingProvider returned no embedding for upsertItem text');
+    }
+    const initialSnap = snapInitial(item.extractorSelfRating);
+    const provenance = provenanceColumns(item.derivedFrom);
+
+    const result = await this.pool.query<{ id: string }>(
+      `INSERT INTO knowledge_items (
+         tenant_id, external_id, source_type, kind, text, text_canonical_hash,
+         embedding, extractor_self_rating, n_confirmations, last_referenced_at,
+         confidence_snapshot, derived_from_kind, derived_from_session,
+         derived_from_turn_lo, derived_from_turn_hi, derived_from_source,
+         derived_from_locator, extractor_version, metadata
+       )
+       VALUES (
+         $1, $2, $3, $4, $5, $6,
+         $7::vector, $8, 1, now(),
+         $9, $10, $11, $12, $13, $14, $15, $16, $17::jsonb
+       )
+       ON CONFLICT (tenant_id, source_type, text_canonical_hash) DO UPDATE
+         SET
+           n_confirmations = knowledge_items.n_confirmations + 1,
+           last_referenced_at = now(),
+           updated_at = now(),
+           confidence_snapshot = LEAST(
+             1.0,
+             EXCLUDED.extractor_self_rating * 0.6 +
+               LEAST(0.5 + 0.1 * knowledge_items.n_confirmations, 1.0) * 0.4
+           )
+       RETURNING id`,
+      [
+        item.tenantId,
+        item.externalId ?? null,
+        item.sourceType,
+        item.kind,
+        item.text,
+        hash,
+        vectorToText(embedding),
+        item.extractorSelfRating,
+        initialSnap,
+        provenance.kind,
+        provenance.session,
+        provenance.turnLo,
+        provenance.turnHi,
+        provenance.source,
+        provenance.locator,
+        item.extractorVersion,
+        JSON.stringify(item.metadata ?? {}),
+      ],
+    );
+    const row = result.rows[0];
+    if (!row) throw new Error('upsertItem returned no row — should be unreachable');
+    return row.id;
+  }
+
+  async retrieve(query: RetrievalQuery): Promise<RetrievalResult> {
+    const [embedding] = await this.embeddings.embed([query.text]);
+    if (!embedding) {
+      throw new Error('EmbeddingProvider returned no embedding for retrieve query');
+    }
+
+    const filters = query.filters;
+    const result = await this.pool.query<RetrievedRow>(
+      `SELECT
+         id, tenant_id, external_id, source_type, kind, text, text_canonical_hash,
+         extractor_self_rating, n_confirmations, last_referenced_at, confidence_snapshot,
+         derived_from_kind, derived_from_session, derived_from_turn_lo,
+         derived_from_turn_hi, derived_from_source, derived_from_locator,
+         extractor_version, created_at, updated_at, metadata,
+         1 - (embedding <=> $1::vector) AS score
+       FROM knowledge_items
+       WHERE tenant_id = $2
+         AND ($3::text[] IS NULL OR source_type = ANY($3::text[]))
+         AND ($4::text[] IS NULL OR kind = ANY($4::text[]))
+         AND ($5::numeric IS NULL OR confidence_snapshot >= $5::numeric)
+       ORDER BY embedding <=> $1::vector
+       LIMIT $6`,
+      [
+        vectorToText(embedding),
+        query.tenantId,
+        filters?.sourceTypes ? [...filters.sourceTypes] : null,
+        filters?.kinds ? [...filters.kinds] : null,
+        filters?.minConfidence ?? null,
+        query.topK,
+      ],
+    );
+
+    const items: RetrievedKnowledgeItem[] = result.rows.map((row) => {
+      const item = mapItem(row);
+      return {
+        item,
+        score: Number(row.score),
+        // No decay applied at MVP; final == snapshot is the honest "no
+        // further policy" value.
+        confidenceFinal: item.confidenceSnapshot,
+      };
+    });
+
+    return { items };
+  }
+
+  async deleteBySource(sourceId: SourceId): Promise<void> {
+    await this.pool.query('DELETE FROM knowledge_items WHERE derived_from_source = $1', [sourceId]);
+  }
+
+  async deleteByExternalId(tenantId: TenantId, externalId: string): Promise<void> {
+    // Hard-coded source_type filter prevents user-data wipes per port comment.
+    await this.pool.query(
+      `DELETE FROM knowledge_items
+       WHERE tenant_id = $1 AND source_type = 'project_seed' AND external_id = $2`,
+      [tenantId, externalId],
+    );
+  }
+
+  async *listByTenant(tenantId: TenantId, filter: ItemFilter): AsyncIterable<KnowledgeItem> {
+    let offset = 0;
+    while (true) {
+      const result = await this.pool.query<KnowledgeRow>(
+        `SELECT
+           id, tenant_id, external_id, source_type, kind, text, text_canonical_hash,
+           extractor_self_rating, n_confirmations, last_referenced_at, confidence_snapshot,
+           derived_from_kind, derived_from_session, derived_from_turn_lo,
+           derived_from_turn_hi, derived_from_source, derived_from_locator,
+           extractor_version, created_at, updated_at, metadata
+         FROM knowledge_items
+         WHERE tenant_id = $1
+           AND ($2::text[] IS NULL OR source_type = ANY($2::text[]))
+           AND ($3::text[] IS NULL OR kind = ANY($3::text[]))
+           AND ($4::numeric IS NULL OR confidence_snapshot >= $4::numeric)
+         ORDER BY id
+         LIMIT $5 OFFSET $6`,
+        [
+          tenantId,
+          filter.sourceTypes ? [...filter.sourceTypes] : null,
+          filter.kinds ? [...filter.kinds] : null,
+          filter.minConfidence ?? null,
+          LIST_PAGE_SIZE,
+          offset,
+        ],
+      );
+      if (result.rows.length === 0) return;
+      for (const row of result.rows) yield mapItem(row);
+      if (result.rows.length < LIST_PAGE_SIZE) return;
+      offset += LIST_PAGE_SIZE;
+    }
+  }
+}
+
+function snapInitial(extractorSelfRating: number): number {
+  // n=1 → boost = 0.5; snap = rating*0.6 + 0.5*0.4 = rating*0.6 + 0.2.
+  // Range [0.2, 0.8] for rating ∈ [0,1] — well within [0,1] clamp; LEAST
+  // is defensive only.
+  return Math.min(1.0, extractorSelfRating * 0.6 + 0.2);
+}
+
+function vectorToText(v: Float32Array): string {
+  // pgvector's text input format: '[1.0,2.0,...]'. Cast via $N::vector at
+  // call site. We avoid the pgvector-node package — reading vector columns
+  // back is not needed (port doesn't surface embedding) and writes are a
+  // single string concatenation.
+  let s = '[';
+  for (let i = 0; i < v.length; i++) {
+    if (i > 0) s += ',';
+    s += String(v[i]);
+  }
+  return `${s}]`;
+}
+
+interface ProvenanceColumns {
+  readonly kind: 'session' | 'external';
+  readonly session: string | null;
+  readonly turnLo: string | null;
+  readonly turnHi: string | null;
+  readonly source: string | null;
+  readonly locator: string | null;
+}
+
+function provenanceColumns(p: ProvenanceRef): ProvenanceColumns {
+  if (p.kind === 'session') {
+    return {
+      kind: 'session',
+      session: p.sessionId,
+      turnLo: p.turnRange ? p.turnRange[0].toString() : null,
+      turnHi: p.turnRange ? p.turnRange[1].toString() : null,
+      source: null,
+      locator: null,
+    };
+  }
+  return {
+    kind: 'external',
+    session: null,
+    turnLo: null,
+    turnHi: null,
+    source: p.sourceId,
+    locator: p.locator,
+  };
+}
+
+function mapProvenance(row: KnowledgeRow): ProvenanceRef {
+  if (row.derived_from_kind === 'session') {
+    const turnRange =
+      row.derived_from_turn_lo !== null && row.derived_from_turn_hi !== null
+        ? ([BigInt(row.derived_from_turn_lo), BigInt(row.derived_from_turn_hi)] as const)
+        : null;
+    return {
+      kind: 'session',
+      sessionId: row.derived_from_session,
+      turnRange,
+      // Schema doesn't carry a "lost-at" timestamp; honest null when source
+      // is unknown rather than approximating with updated_at.
+      provenanceLostAt: null,
+    };
+  }
+  // external: CHECK constraint guarantees derived_from_source is NOT NULL,
+  // and adapter writes locator alongside it.
+  if (row.derived_from_source === null || row.derived_from_locator === null) {
+    throw new Error(
+      `external-provenance row ${row.id} has null derived_from_source or derived_from_locator`,
+    );
+  }
+  return {
+    kind: 'external',
+    sourceId: row.derived_from_source,
+    locator: row.derived_from_locator,
+  };
+}
+
+function mapItem(row: KnowledgeRow): KnowledgeItem {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    ...(row.external_id !== null ? { externalId: row.external_id } : {}),
+    sourceType: row.source_type as SourceType,
+    kind: row.kind as KnowledgeKind,
+    text: row.text,
+    textCanonicalHash: row.text_canonical_hash,
+    extractorSelfRating: Number(row.extractor_self_rating),
+    nConfirmations: row.n_confirmations,
+    lastReferencedAt: row.last_referenced_at,
+    confidenceSnapshot: Number(row.confidence_snapshot),
+    derivedFrom: mapProvenance(row),
+    extractorVersion: row.extractor_version,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    metadata: row.metadata,
+  };
+}

--- a/packages/core/src/ports/knowledge-store.ts
+++ b/packages/core/src/ports/knowledge-store.ts
@@ -11,8 +11,10 @@ export interface KnowledgeStore {
   upsertItem(item: KnowledgeItemInput): Promise<KnowledgeId>;
   retrieve(query: RetrievalQuery): Promise<RetrievalResult>;
   deleteBySource(sourceId: SourceId): Promise<void>;
-  // Filters internally to source_type='project_seed' so calling with a
-  // user-data externalId can't wipe distilled session knowledge.
+  // Adapter implementations MUST filter internally to source_type='project_seed'.
+  // The pgvector schema's UNIQUE(tenant_id, external_id) index already makes
+  // collisions across source_types impossible, so this filter is defense-in-depth
+  // against future schema relaxation rather than a guard against current data.
   deleteByExternalId(tenantId: TenantId, externalId: string): Promise<void>;
   listByTenant(tenantId: TenantId, filter: ItemFilter): AsyncIterable<KnowledgeItem>;
 }


### PR DESCRIPTION
## Summary

Concrete `KnowledgeStore` adapter against the Postgres + pgvector schema (#20), conforming to the port lifted in #36. Constructor takes `pg.Pool` + `EmbeddingProvider` — composition root wires both.

This is the third storage adapter (after migration runner and PgvectorSessionStore #42), and the last storage piece needed for #21.

## What changed

`packages/adapter-store-pgvector/src/`:
- `knowledge-store/canonicalize.ts` — `canonicalize(text)` (lowercase, collapse whitespace, strip trailing punctuation per design §3) + `canonicalHash(text)` (SHA-256 hex). 9 unit tests.
- `knowledge-store/pgvector-knowledge-store.ts` — class implementing all 6 KnowledgeStore methods.
- `__integration__/knowledge-store.integration.test.ts` — 12 testcontainer scenarios covering all methods + provenance round-trip + 250-row pagination.

`packages/core/src/ports/knowledge-store.ts` — clarified `deleteByExternalId` comment to reflect schema reality (see "Documentation fix" below).

### SQL / algorithm choices

- **`recordSource`**: `INSERT ... ON CONFLICT DO UPDATE SET metadata = source_refs.metadata || $4::jsonb` — idempotent, JSONB merge.
- **`upsertItem`**:
  - Initial snap = `clamp(rating * 0.6 + 0.5 * 0.4)` computed in TS.
  - `ON CONFLICT (tenant_id, source_type, text_canonical_hash)` — bumps `n_confirmations`, recomputes snap server-side as `LEAST(1.0, EXCLUDED.extractor_self_rating * 0.6 + LEAST(0.5 + 0.1 * knowledge_items.n_confirmations, 1.0) * 0.4)`. The `knowledge_items.n_confirmations` reference is the OLD value (per ON CONFLICT semantics), and `boost(n_new) = 0.5 + 0.1 * (n_new - 1) = 0.5 + 0.1 * n_old`, so the formula is correct.
  - Embeddings written via `$N::vector` text-format cast — pgvector-node package not needed since we never read the column back through the port.
- **`retrieve`**: `ORDER BY embedding <=> $vec LIMIT topK` with optional filters via `($N::T[] IS NULL OR col = ANY($N))`. Score = `1 - cosine_distance`. `confidenceFinal = confidenceSnapshot` (advisor note: honest "no decay policy" value rather than undefined).
- **`deleteBySource`**: `WHERE derived_from_source = $1`.
- **`deleteByExternalId`**: hard-coded `source_type = 'project_seed'` filter — defense-in-depth (see "Documentation fix" below).
- **`listByTenant`**: AsyncIterable with `LIMIT 200 OFFSET k` pagination.

## Out of scope (filed in issue body)

- Near-duplicate vector check (design §3.3 cosine-similarity scan) — hash-based dedup sufficient for MVP.
- Recency decay at query time (`applyRecencyDecay`) — port carries the field, adapter ignores it for MVP.
- Cursor-based pagination for `listByTenant` — OFFSET fine for MVP.
- Graph layer `searchRelational` — Phase 2+.

## Documentation fix (port comment)

The previous `deleteByExternalId` comment implied cross-`source_type` externalId collisions were possible. They aren't — the schema's `UNIQUE(tenant_id, external_id) WHERE external_id IS NOT NULL` index makes externalId globally unique per tenant. The hard-coded `source_type='project_seed'` filter is defense-in-depth against future schema relaxation, not a guard against current data. Comment updated to match.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (biome)
- [x] `pnpm test` — 78 passed, 26 skipped (integration default-skip)
- [x] `pnpm depcheck` — no new violations
- [x] **`INTEGRATION=1 pnpm --filter @agentry/adapter-store-pgvector test`** — 40 passed (incl. 12 new knowledge-store integration scenarios). Verified against real `pgvector/pgvector:pg17` container.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)