### PR TITLE
feat(core): lift SessionPolicy port (#52)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -253,6 +253,14 @@ interface SessionPolicy {
   idleTimeoutMinutes(): number;
   shouldEndOn(e: SessionLifecycleEvent): boolean;
 }
+
+// Open kind. Common values: 'idle_timeout' (JobRunner-fired after
+// idleTimeoutMinutes), 'channel_close' (CLI process exit, Slack channel
+// archive), 'user_left'. Channel adapters can introduce their own.
+interface SessionLifecycleEvent {
+  kind: string;
+  metadata?: Record<string, unknown>;
+}
 ```
 
 **Per-channel policy table**

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -34,6 +34,7 @@ export type {
   ChannelNativeRef,
   DistillationCriteria,
   Session,
+  SessionLifecycleEvent,
   SessionStatus,
   Turn,
   TurnInput,

--- a/packages/core/src/domain/session.ts
+++ b/packages/core/src/domain/session.ts
@@ -46,6 +46,16 @@ export interface Turn extends TurnInput {
   readonly createdAt: Date;
 }
 
+// Open kind. Common values: 'idle_timeout' (JobRunner-fired after
+// SessionPolicy.idleTimeoutMinutes), 'channel_close' (CLI process exit,
+// Slack channel archive), 'user_left'. Channel adapters can introduce
+// their own kinds — SessionPolicy.shouldEndOn decides per channel whether
+// the kind closes the session.
+export interface SessionLifecycleEvent {
+  readonly kind: string;
+  readonly metadata?: Readonly<Record<string, unknown>>;
+}
+
 // Trigger taxonomy from `docs/design/knowledge-store.md` §5.1. `rolling` is
 // disabled by default; see design doc for per-trigger policy.
 export type DistillationCriteria =

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -13,4 +13,5 @@ export type {
 } from './job-runner.js';
 export type { KnowledgeStore } from './knowledge-store.js';
 export type { OutboundChannel } from './outbound-channel.js';
+export type { SessionPolicy } from './session-policy.js';
 export type { SessionStore } from './session-store.js';

--- a/packages/core/src/ports/session-policy.test.ts
+++ b/packages/core/src/ports/session-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { IncomingEvent } from '../domain/channel.js';
+import type { SessionPolicy } from './session-policy.js';
+
+// Compile + runtime smoke. Mirrors a Slack-channel-style policy enough to
+// pin the contract: native-ref derived from threading metadata, idle 24h,
+// `idle_timeout` ends sessions, `channel_close` does too, anything else
+// stays open.
+function buildFake(): SessionPolicy {
+  return {
+    channelKind: 'fake',
+    computeNativeRef(event) {
+      const thread = event.threading.thread_ts;
+      const ref = typeof thread === 'string' ? thread : event.idempotencyKey;
+      return `fake:${ref}`;
+    },
+    idleTimeoutMinutes() {
+      return 24 * 60;
+    },
+    shouldEndOn(event) {
+      return event.kind === 'idle_timeout' || event.kind === 'channel_close';
+    },
+  };
+}
+
+const baseEvent: IncomingEvent = {
+  channelKind: 'fake',
+  channelNativeRef: 'unused-during-policy-eval',
+  author: { channelUserId: 'u1' },
+  payload: { text: 'hi' },
+  threading: { thread_ts: '1704067200.123' },
+  receivedAt: new Date(),
+  idempotencyKey: 'k1',
+};
+
+describe('SessionPolicy port', () => {
+  it('admits a minimal in-memory implementation', () => {
+    const policy = buildFake();
+    expect(policy.channelKind).toBe('fake');
+    expect(policy.idleTimeoutMinutes()).toBe(24 * 60);
+  });
+
+  it('computes native ref from threading metadata', () => {
+    const policy = buildFake();
+    expect(policy.computeNativeRef(baseEvent)).toBe('fake:1704067200.123');
+  });
+
+  it('falls back when threading lacks the expected key', () => {
+    const policy = buildFake();
+    expect(policy.computeNativeRef({ ...baseEvent, threading: {} })).toBe('fake:k1');
+  });
+
+  it('shouldEndOn distinguishes lifecycle event kinds', () => {
+    const policy = buildFake();
+    expect(policy.shouldEndOn({ kind: 'idle_timeout' })).toBe(true);
+    expect(policy.shouldEndOn({ kind: 'channel_close' })).toBe(true);
+    expect(policy.shouldEndOn({ kind: 'user_left' })).toBe(false);
+    expect(policy.shouldEndOn({ kind: 'channel_archived' })).toBe(false);
+  });
+});

--- a/packages/core/src/ports/session-policy.ts
+++ b/packages/core/src/ports/session-policy.ts
@@ -1,0 +1,21 @@
+import type { IncomingEvent } from '../domain/channel.js';
+import type { ChannelKind, ChannelNativeRef, SessionLifecycleEvent } from '../domain/session.js';
+
+// Per-channel routing + lifecycle strategy. Concrete adapters bring their
+// own implementation (e.g. SlackPolicy, CliPolicy) alongside their channel
+// adapter; the composition root maps `channelKind` → `SessionPolicy`.
+//
+// `computeNativeRef` is pure and synchronous: given an inbound event, it
+// returns the channel-specific session key (Slack: `slack:${channel_id}:
+// ${thread_ts}`; CLI: `AGENT_SESSION_ID` or PID; etc.). The framework uses
+// this to look up or create a Session via SessionStore.findOrCreate.
+//
+// `shouldEndOn` is the lifecycle predicate: given a lifecycle event the
+// framework observed (idle timer fired, transport closed, ...), decide
+// whether THIS channel's policy treats it as "session ended".
+export interface SessionPolicy {
+  readonly channelKind: ChannelKind;
+  computeNativeRef(event: IncomingEvent): ChannelNativeRef;
+  idleTimeoutMinutes(): number;
+  shouldEndOn(event: SessionLifecycleEvent): boolean;
+}


### PR DESCRIPTION
## Summary

Type-only lift of `SessionPolicy` (ARCHITECTURE.md §4.3) into `packages/core`. `SessionStore` was lifted in #40; this completes the design issue #8 lift surface. Mirrors the #36 / #40 / #44 / #50 pattern.

## What changed

`packages/core/src/domain/session.ts` — added `SessionLifecycleEvent`:

```ts
interface SessionLifecycleEvent {
  readonly kind: string;
  readonly metadata?: Readonly<Record<string, unknown>>;
}
```

Open `kind` follows the `ChannelKind` / `SourceKind` precedent. Common values documented as `'idle_timeout'`, `'channel_close'`, `'user_left'`; channel adapters can introduce their own.

`packages/core/src/ports/session-policy.ts` (new):

```ts
interface SessionPolicy {
  readonly channelKind: ChannelKind;
  computeNativeRef(event: IncomingEvent): ChannelNativeRef;
  idleTimeoutMinutes(): number;
  shouldEndOn(event: SessionLifecycleEvent): boolean;
}
```

Per-channel routing + lifecycle strategy. Concrete adapters (Slack, CLI, etc.) bring their own `SessionPolicy` alongside their channel adapter; composition root maps `channelKind` → `SessionPolicy`.

`session-policy.test.ts` — conformance test pinning all four contract surfaces: `channelKind`, `idleTimeoutMinutes`, `computeNativeRef` (with threading present and threading absent), and `shouldEndOn` discrimination across multiple lifecycle kinds.

`ARCHITECTURE.md §4.3` — added concrete shape for `SessionLifecycleEvent` (previously referenced but undefined).

## Out of scope (filed in issue body)

- Concrete per-channel policies (Slack, CLI, HTTP) — land with their channel adapters (#18 + downstream).
- A registry mapping `channelKind` → `SessionPolicy` — composition-root concern.
- Idle-timeout dispatch (JobRunner emitting `idle_timeout` events) — use-case layer.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (biome)
- [x] `pnpm test` — 86 passed, 26 skipped (4 new conformance tests)
- [x] `pnpm depcheck` — no new violations

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)