### PR TITLE
feat(core): lift Logger port (#54)

### DIFF
--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -12,6 +12,7 @@ export type {
   JobRunnerEnqueueOptions,
 } from './job-runner.js';
 export type { KnowledgeStore } from './knowledge-store.js';
+export type { Logger } from './logger.js';
 export type { OutboundChannel } from './outbound-channel.js';
 export type { SessionPolicy } from './session-policy.js';
 export type { SessionStore } from './session-store.js';

--- a/packages/core/src/ports/logger.test.ts
+++ b/packages/core/src/ports/logger.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { Logger } from './logger.js';
+
+type Level = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+interface LogEntry {
+  readonly level: Level;
+  readonly bindings: Readonly<Record<string, unknown>>;
+  readonly obj: object;
+  readonly msg?: string;
+}
+
+// Compile + runtime smoke. The fake records every emit with the merged
+// bindings so adapter-style override semantics are observable in tests.
+function buildFake(
+  initial: Record<string, unknown> = {},
+): Logger & { readonly entries: readonly LogEntry[] } {
+  const entries: LogEntry[] = [];
+  const make = (bindings: Record<string, unknown>): Logger => {
+    const emit = (level: Level, obj: object, msg?: string): void => {
+      entries.push(msg === undefined ? { level, bindings, obj } : { level, bindings, obj, msg });
+    };
+    return {
+      trace: (obj, msg) => emit('trace', obj, msg),
+      debug: (obj, msg) => emit('debug', obj, msg),
+      info: (obj, msg) => emit('info', obj, msg),
+      warn: (obj, msg) => emit('warn', obj, msg),
+      error: (obj, msg) => emit('error', obj, msg),
+      fatal: (obj, msg) => emit('fatal', obj, msg),
+      // Inner bindings override outer on key collision per pino convention.
+      child: (b) => make({ ...bindings, ...(b as Record<string, unknown>) }),
+    };
+  };
+  const root = make(initial);
+  return Object.assign(root, {
+    get entries() {
+      return entries;
+    },
+  });
+}
+
+describe('Logger port', () => {
+  it('admits a minimal in-memory implementation with all six levels', () => {
+    const logger = buildFake();
+    logger.trace({ k: 1 }, 'trace');
+    logger.debug({ k: 2 }, 'debug');
+    logger.info({ k: 3 }, 'info');
+    logger.warn({ k: 4 }, 'warn');
+    logger.error({ k: 5 }, 'error');
+    logger.fatal({ k: 6 }, 'fatal');
+
+    expect(logger.entries.map((e) => e.level)).toEqual([
+      'trace',
+      'debug',
+      'info',
+      'warn',
+      'error',
+      'fatal',
+    ]);
+    expect(logger.entries[2]?.obj).toEqual({ k: 3 });
+    expect(logger.entries[2]?.msg).toBe('info');
+  });
+
+  it('child() merges bindings cumulatively across nesting', () => {
+    const logger = buildFake();
+    const a = logger.child({ tenantId: 't1' });
+    const b = a.child({ sessionId: 's1' });
+    b.info({ k: 1 }, 'hello');
+
+    const entry = logger.entries.at(-1);
+    expect(entry?.bindings).toEqual({ tenantId: 't1', sessionId: 's1' });
+  });
+
+  it('child() inner bindings override outer on key collision (pino convention)', () => {
+    const logger = buildFake();
+    const a = logger.child({ sessionId: 'A' });
+    const b = a.child({ sessionId: 'B' });
+    b.info({ k: 1 });
+
+    const entry = logger.entries.at(-1);
+    expect(entry?.bindings).toEqual({ sessionId: 'B' });
+  });
+
+  it('omitting msg is permitted', () => {
+    const logger = buildFake();
+    logger.info({ k: 1 });
+    expect(logger.entries[0]?.msg).toBeUndefined();
+  });
+});

--- a/packages/core/src/ports/logger.ts
+++ b/packages/core/src/ports/logger.ts
@@ -1,0 +1,21 @@
+// Structured logger contract. Mirrors the pino API (the default adapter)
+// — six level methods plus `child()` for bindings propagation. Per
+// ARCHITECTURE.md §4.7, recommended standard keys are: `tenantId`,
+// `sessionId`, `turnId`, `channelKind`, `channelNativeRef`, `traceId`,
+// `adapterKind`. Use cases create child loggers bound to the current
+// session for context propagation.
+//
+// `obj: object` (not `Record<string, unknown>`) preserves compatibility
+// with pino-shaped subclasses callers may want to pass; primitives are
+// rejected at the type level so `info('hello')` won't compile.
+export interface Logger {
+  trace(obj: object, msg?: string): void;
+  debug(obj: object, msg?: string): void;
+  info(obj: object, msg?: string): void;
+  warn(obj: object, msg?: string): void;
+  error(obj: object, msg?: string): void;
+  fatal(obj: object, msg?: string): void;
+  // Returns a new logger; bindings are merged into every subsequent log
+  // line. Inner bindings override outer on key collision (pino convention).
+  child(bindings: object): Logger;
+}


### PR DESCRIPTION
## Summary

Type-only lift of `Logger` (ARCHITECTURE.md §4.7) into `packages/core`. Mirrors the #36 / #40 / #44 / #50 / #52 pattern: interface + conformance test + re-export, no adapter. PinoLogger adapter follows in #55.

## What changed

`packages/core/src/ports/logger.ts` (new) — `Logger` interface:

```ts
interface Logger {
  trace(obj: object, msg?: string): void;
  debug(obj: object, msg?: string): void;
  info(obj: object, msg?: string): void;
  warn(obj: object, msg?: string): void;
  error(obj: object, msg?: string): void;
  fatal(obj: object, msg?: string): void;
  child(bindings: object): Logger;
}
```

The shape is pino's API 1:1 — six level methods plus `child(bindings)` for context propagation. `obj: object` (not `Record<string, unknown>`) preserves compatibility with pino-shaped subclasses callers may want to pass; primitives are rejected at the type level so `info('hello')` won't compile.

`logger.test.ts` (new) — conformance test pinning four contract surfaces:

- All six level methods are callable
- `child()` merges bindings cumulatively across nesting
- **Inner bindings override outer on key collision** (pino convention) — caught by advisor as the contract that would otherwise silently diverge between adapters
- Omitting `msg` is permitted

`ports/index.ts` — re-export.

## Out of scope (filed in issue body and #55)

- pino adapter — #55
- Standard log-key documentation — already in ARCHITECTURE.md §4.7; the port itself is structurally agnostic
- Log-level config — adapter concern
- Async / batching / transport — adapter concern

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (biome)
- [x] `pnpm test` — 90 passed, 26 skipped (4 new conformance tests)
- [x] `pnpm depcheck` — no new violations

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)