### PR TITLE
feat(adapter-logger-pino): PinoLogger (#55)

### DIFF
--- a/packages/adapter-logger-pino/package.json
+++ b/packages/adapter-logger-pino/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@agentry/adapter-logger-pino",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@agentry/core": "workspace:*",
+    "pino": "^10.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.2"
+  }
+}

--- a/packages/adapter-logger-pino/src/index.ts
+++ b/packages/adapter-logger-pino/src/index.ts
@@ -1,0 +1,2 @@
+export type { PinoLoggerOptions, PinoLogLevel } from './pino-logger.js';
+export { PinoLogger } from './pino-logger.js';

--- a/packages/adapter-logger-pino/src/pino-logger.test.ts
+++ b/packages/adapter-logger-pino/src/pino-logger.test.ts
@@ -1,0 +1,119 @@
+import { Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { PinoLogger } from './pino-logger.js';
+
+class CaptureStream extends Writable {
+  private buffer = '';
+  readonly entries: Array<Record<string, unknown>> = [];
+
+  override _write(
+    chunk: Buffer | string,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    this.buffer += typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    while (true) {
+      const idx = this.buffer.indexOf('\n');
+      if (idx < 0) break;
+      const line = this.buffer.slice(0, idx);
+      this.buffer = this.buffer.slice(idx + 1);
+      if (line) this.entries.push(JSON.parse(line) as Record<string, unknown>);
+    }
+    callback();
+  }
+}
+
+const PINO_LEVELS = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+} as const;
+
+describe('PinoLogger', () => {
+  it('emits all six levels with correct level numbers, msg, and obj keys', () => {
+    const stream = new CaptureStream();
+    const logger = PinoLogger.create({ level: 'trace', destination: stream });
+
+    logger.trace({ a: 1 }, 'trace-msg');
+    logger.debug({ a: 2 }, 'debug-msg');
+    logger.info({ a: 3 }, 'info-msg');
+    logger.warn({ a: 4 }, 'warn-msg');
+    logger.error({ a: 5 }, 'error-msg');
+    logger.fatal({ a: 6 }, 'fatal-msg');
+
+    const levels = Object.keys(PINO_LEVELS) as Array<keyof typeof PINO_LEVELS>;
+    expect(stream.entries).toHaveLength(6);
+    levels.forEach((name, i) => {
+      expect(stream.entries[i]).toMatchObject({
+        level: PINO_LEVELS[name],
+        msg: `${name}-msg`,
+        a: i + 1,
+      });
+    });
+  });
+
+  it('applies constructor bindings to every line', () => {
+    const stream = new CaptureStream();
+    const logger = PinoLogger.create({
+      destination: stream,
+      bindings: { tenantId: 't1', adapterKind: 'pino' },
+    });
+
+    logger.info({ k: 1 }, 'first');
+    logger.info({ k: 2 }, 'second');
+
+    expect(stream.entries).toHaveLength(2);
+    for (const entry of stream.entries) {
+      expect(entry).toMatchObject({ tenantId: 't1', adapterKind: 'pino' });
+    }
+  });
+
+  it('child() merges bindings cumulatively across nesting', () => {
+    const stream = new CaptureStream();
+    const root = PinoLogger.create({ destination: stream });
+    const a = root.child({ tenantId: 't1' });
+    const b = a.child({ sessionId: 's1' });
+    b.info({ k: 1 }, 'hello');
+
+    const entry = stream.entries.at(-1);
+    expect(entry).toMatchObject({ tenantId: 't1', sessionId: 's1', msg: 'hello' });
+  });
+
+  it('child() inner bindings override outer on key collision (pino convention)', () => {
+    const stream = new CaptureStream();
+    const root = PinoLogger.create({ destination: stream });
+    const a = root.child({ sessionId: 'A' });
+    const b = a.child({ sessionId: 'B' });
+    b.info({ k: 1 });
+
+    const entry = stream.entries.at(-1);
+    expect(entry?.sessionId).toBe('B');
+  });
+
+  it('level filter suppresses calls below the threshold', () => {
+    const stream = new CaptureStream();
+    const logger = PinoLogger.create({ level: 'warn', destination: stream });
+
+    logger.trace({}, 'trace');
+    logger.debug({}, 'debug');
+    logger.info({}, 'info');
+    logger.warn({}, 'warn');
+    logger.error({}, 'error');
+
+    const msgs = stream.entries.map((e) => e.msg);
+    expect(msgs).toEqual(['warn', 'error']);
+  });
+
+  it("level: 'silent' suppresses all output", () => {
+    const stream = new CaptureStream();
+    const logger = PinoLogger.create({ level: 'silent', destination: stream });
+
+    logger.error({}, 'this should not appear');
+    logger.fatal({}, 'neither should this');
+
+    expect(stream.entries).toHaveLength(0);
+  });
+});

--- a/packages/adapter-logger-pino/src/pino-logger.ts
+++ b/packages/adapter-logger-pino/src/pino-logger.ts
@@ -1,0 +1,60 @@
+import type { Logger } from '@agentry/core';
+import pino, { type Logger as PinoBase } from 'pino';
+
+// pino accepts seven level filters; the port (#54) only declares six call
+// methods. `silent` is a *threshold* (suppress all output), not a level you
+// emit at — it's coherent to expose here without growing the port surface.
+export type PinoLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal' | 'silent';
+
+export interface PinoLoggerOptions {
+  readonly level?: PinoLogLevel;
+  readonly bindings?: Readonly<Record<string, unknown>>;
+  // Pass a Writable for tests; default is pino's default (stdout). pino
+  // writes synchronously when given a plain Writable (no SonicBoom buffering).
+  readonly destination?: NodeJS.WritableStream;
+}
+
+export class PinoLogger implements Logger {
+  // Private constructor + static factory so callers can't bypass the
+  // options bag; `child()` is the only path that wraps a pre-built pino
+  // instance, preserving pino's native child-binding inheritance.
+  private constructor(private readonly inner: PinoBase) {}
+
+  static create(options: PinoLoggerOptions = {}): PinoLogger {
+    const opts = { level: options.level ?? 'info' };
+    let p = options.destination ? pino(opts, options.destination) : pino(opts);
+    if (options.bindings) p = p.child(options.bindings);
+    return new PinoLogger(p);
+  }
+
+  trace(obj: object, msg?: string): void {
+    this.inner.trace(obj, msg);
+  }
+
+  debug(obj: object, msg?: string): void {
+    this.inner.debug(obj, msg);
+  }
+
+  info(obj: object, msg?: string): void {
+    this.inner.info(obj, msg);
+  }
+
+  warn(obj: object, msg?: string): void {
+    this.inner.warn(obj, msg);
+  }
+
+  error(obj: object, msg?: string): void {
+    this.inner.error(obj, msg);
+  }
+
+  fatal(obj: object, msg?: string): void {
+    this.inner.fatal(obj, msg);
+  }
+
+  // The port's `child(bindings)` is binding-only by design. For per-child
+  // level overrides or msgPrefix (pino-native features), construct a fresh
+  // `PinoLogger.create({ level, bindings })` instead.
+  child(bindings: object): Logger {
+    return new PinoLogger(this.inner.child(bindings));
+  }
+}

--- a/packages/adapter-logger-pino/tsconfig.json
+++ b/packages/adapter-logger-pino/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules"],
+  "references": [{ "path": "../core" }]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,19 @@ importers:
         specifier: ^24.12.2
         version: 24.12.2
 
+  packages/adapter-logger-pino:
+    dependencies:
+      '@agentry/core':
+        specifier: workspace:*
+        version: link:../core
+      pino:
+        specifier: ^10.1.0
+        version: 10.3.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
+
   packages/adapter-runner-claude-cli:
     dependencies:
       '@agentry/core':
@@ -396,6 +409,9 @@ packages:
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -660,6 +676,10 @@ packages:
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -1124,6 +1144,10 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -1185,6 +1209,16 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1208,6 +1242,9 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   process@0.11.10:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
@@ -1230,6 +1267,9 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -1243,6 +1283,10 @@ packages:
 
   readdir-glob@1.1.3:
     resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -1282,6 +1326,10 @@ packages:
   safe-regex@2.1.1:
     resolution: {integrity: sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -1310,6 +1358,9 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -1397,6 +1448,10 @@ packages:
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1779,6 +1834,8 @@ snapshots:
 
   '@oxc-project/types@0.127.0': {}
 
+  '@pinojs/redact@0.4.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -2018,6 +2075,8 @@ snapshots:
   async-lock@1.4.1: {}
 
   async@3.2.6: {}
+
+  atomic-sleep@1.0.0: {}
 
   b4a@1.8.0: {}
 
@@ -2438,6 +2497,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -2494,6 +2555,26 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
   postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
@@ -2511,6 +2592,8 @@ snapshots:
       xtend: 4.0.2
 
   process-nextick-args@2.0.1: {}
+
+  process-warning@5.0.0: {}
 
   process@0.11.10: {}
 
@@ -2552,6 +2635,8 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  quick-format-unescaped@4.0.4: {}
+
   readable-stream@2.3.8:
     dependencies:
       core-util-is: 1.0.3
@@ -2579,6 +2664,8 @@ snapshots:
   readdir-glob@1.1.3:
     dependencies:
       minimatch: 5.1.9
+
+  real-require@0.2.0: {}
 
   rechoir@0.8.0:
     dependencies:
@@ -2628,6 +2715,8 @@ snapshots:
     dependencies:
       regexp-tree: 0.1.27
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   semver@7.7.4: {}
@@ -2645,6 +2734,10 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
 
   source-map-js@1.2.1: {}
 
@@ -2789,6 +2882,10 @@ snapshots:
       b4a: 1.8.0
     transitivePeerDependencies:
       - react-native-b4a
+
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
 
   tinybench@2.9.0: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
       "@agentry/adapter-runner-claude-cli": ["packages/adapter-runner-claude-cli/src/index.ts"],
       "@agentry/adapter-jobrunner-memory": ["packages/adapter-jobrunner-memory/src/index.ts"],
       "@agentry/adapter-store-pgvector": ["packages/adapter-store-pgvector/src/index.ts"],
-      "@agentry/adapter-embedding-voyage": ["packages/adapter-embedding-voyage/src/index.ts"]
+      "@agentry/adapter-embedding-voyage": ["packages/adapter-embedding-voyage/src/index.ts"],
+      "@agentry/adapter-logger-pino": ["packages/adapter-logger-pino/src/index.ts"]
     }
   },
   "files": [],
@@ -20,6 +21,7 @@
     { "path": "packages/adapter-jobrunner-memory" },
     { "path": "packages/adapter-store-pgvector" },
     { "path": "packages/adapter-embedding-voyage" },
+    { "path": "packages/adapter-logger-pino" },
     { "path": "apps/server" },
     { "path": "apps/cli" }
   ]


### PR DESCRIPTION
## Summary

Concrete `Logger` adapter wrapping pino, conforming to the port lifted in #54. Mirrors the established port-then-adapter pattern from #44 → #45.

## What changed

New package `@agentry/adapter-logger-pino` (workspace deps: `@agentry/core`, `pino@^10.1.0`).

`src/pino-logger.ts`:
- `PinoLogger.create({ level?, bindings?, destination? })` static factory with private constructor — `child()` is the only path that wraps a pre-built pino instance, preserving pino's native child-binding inheritance.
- `level` defaults to `'info'`. `'silent'` is accepted as a *threshold* (suppresses all output) without growing the port's six-method surface.
- `destination` accepts a `NodeJS.WritableStream` for tests; pino writes synchronously to plain Node Writables (no SonicBoom buffering).
- `child(bindings: object): Logger` is binding-only by design (the port carries no options arg). For per-child level overrides or `msgPrefix`, callers construct a fresh `PinoLogger.create({...})` instead — comment in source flags this for discoverability.

`src/pino-logger.test.ts` — 6 unit tests using a `CaptureStream` (Writable subclass) that captures and parses emitted JSON lines:
- All six levels emit correct `level` numbers / `msg` / `obj` keys
- Constructor `bindings` apply to every line
- `child()` accumulates bindings across nesting
- Inner-wins on key collision (matches the port's #54 contract)
- `level: 'warn'` filter suppresses `trace`/`debug`/`info`
- `level: 'silent'` suppresses everything

`tsconfig.json` (root) — workspace path mapping + project reference.

## Out of scope (filed in issue body)

- Pretty-printing transport (`pino-pretty`) — composition concern; adapter ships JSON only.
- File / network transports — composition concern.
- Per-child level overrides — fresh `PinoLogger.create()` instead.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (biome)
- [x] `pnpm test` — 96 passed, 26 skipped (6 new unit tests)
- [x] `pnpm depcheck` — no new violations

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)