### PR TITLE
feat(adapter-channel-slack): Slack channel adapter package (part 1 of #18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ packages/
   core/                   # domain + ports + use cases (zero runtime deps)
   testing/                # in-memory adapters for use-case tests
   runtime/                # composition root, config schema (#27)
-  adapter-channel-slack/  # to be added in #18
+  adapter-channel-slack/  # Slack channel adapter (events API, threads as sessions)
   adapter-runner-claude-cli/  # Claude CLI subprocess runner (#19)
   adapter-store-pgvector/ # Postgres + pgvector schema migrations (#20)
   ...                     # other adapters per ARCHITECTURE.md §6

--- a/packages/adapter-channel-slack/package.json
+++ b/packages/adapter-channel-slack/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@agentry/adapter-channel-slack",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@agentry/core": "workspace:*",
+    "@slack/bolt": "^4.7.1",
+    "@slack/web-api": "^7.15.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.12.2"
+  }
+}

--- a/packages/adapter-channel-slack/src/index.ts
+++ b/packages/adapter-channel-slack/src/index.ts
@@ -1,0 +1,22 @@
+export { SLACK_CHANNEL_KIND, SLACK_DM_CHANNEL_KIND } from './slack-channel-kinds.js';
+export {
+  mapAppMentionToIncomingEvent,
+  type SlackAppMentionEnvelope,
+  SlackEventMappingError,
+} from './slack-event-mapping.js';
+export {
+  SLACK_REQUIRED_SCOPES_PR1,
+  SlackInboundChannel,
+  type SlackInboundChannelOptions,
+} from './slack-inbound-channel.js';
+export {
+  SlackOutboundChannel,
+  SlackOutboundChannelError,
+  type SlackOutboundChannelOptions,
+} from './slack-outbound-channel.js';
+export {
+  type SlackAuthInfo,
+  SlackScopeError,
+  verifySlackScopes,
+} from './slack-scope-verifier.js';
+export { SlackSessionPolicy } from './slack-session-policy.js';

--- a/packages/adapter-channel-slack/src/index.ts
+++ b/packages/adapter-channel-slack/src/index.ts
@@ -1,4 +1,4 @@
-export { SLACK_CHANNEL_KIND, SLACK_DM_CHANNEL_KIND } from './slack-channel-kinds.js';
+export { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
 export {
   mapAppMentionToIncomingEvent,
   type SlackAppMentionEnvelope,

--- a/packages/adapter-channel-slack/src/slack-channel-kinds.ts
+++ b/packages/adapter-channel-slack/src/slack-channel-kinds.ts
@@ -1,4 +1,3 @@
 import type { ChannelKind } from '@agentry/core';
 
 export const SLACK_CHANNEL_KIND: ChannelKind = 'slack';
-export const SLACK_DM_CHANNEL_KIND: ChannelKind = 'slack-dm';

--- a/packages/adapter-channel-slack/src/slack-channel-kinds.ts
+++ b/packages/adapter-channel-slack/src/slack-channel-kinds.ts
@@ -1,0 +1,4 @@
+import type { ChannelKind } from '@agentry/core';
+
+export const SLACK_CHANNEL_KIND: ChannelKind = 'slack';
+export const SLACK_DM_CHANNEL_KIND: ChannelKind = 'slack-dm';

--- a/packages/adapter-channel-slack/src/slack-event-mapping.test.ts
+++ b/packages/adapter-channel-slack/src/slack-event-mapping.test.ts
@@ -75,4 +75,14 @@ describe('mapAppMentionToIncomingEvent', () => {
       SlackEventMappingError,
     );
   });
+
+  it('throws SlackEventMappingError when event_id is missing', () => {
+    const env = { ...buildEnvelope(), event_id: '' };
+    expect(() => mapAppMentionToIncomingEvent(env)).toThrow(/event_id/);
+  });
+
+  it('throws SlackEventMappingError when team_id is missing', () => {
+    const env = { ...buildEnvelope(), team_id: '' };
+    expect(() => mapAppMentionToIncomingEvent(env)).toThrow(/team_id/);
+  });
 });

--- a/packages/adapter-channel-slack/src/slack-event-mapping.test.ts
+++ b/packages/adapter-channel-slack/src/slack-event-mapping.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mapAppMentionToIncomingEvent,
+  type SlackAppMentionEnvelope,
+  SlackEventMappingError,
+} from './slack-event-mapping.js';
+
+function buildEnvelope(
+  overrides: Partial<SlackAppMentionEnvelope['event']> = {},
+): SlackAppMentionEnvelope {
+  return {
+    event_id: 'Ev0123ABCD',
+    team_id: 'T0G9PQBBK',
+    event: {
+      type: 'app_mention',
+      user: 'U123USER',
+      text: '<@UBOTID> hello',
+      ts: '1700000123.000200',
+      thread_ts: '1700000000.000100',
+      channel: 'C9876CHAN',
+      event_ts: '1700000123.000200',
+      ...overrides,
+    },
+  };
+}
+
+describe('mapAppMentionToIncomingEvent', () => {
+  it('maps a thread reply mention to a canonical IncomingEvent', () => {
+    const incoming = mapAppMentionToIncomingEvent(buildEnvelope());
+
+    expect(incoming.channelKind).toBe('slack');
+    expect(incoming.channelNativeRef).toBe('slack:C9876CHAN:1700000000.000100');
+    expect(incoming.author).toEqual({ channelUserId: 'U123USER' });
+    expect(incoming.payload.text).toBe('<@UBOTID> hello');
+    expect(incoming.threading).toEqual({
+      channel: 'C9876CHAN',
+      message_ts: '1700000123.000200',
+      thread_ts: '1700000000.000100',
+      team_id: 'T0G9PQBBK',
+    });
+    expect(incoming.idempotencyKey).toBe('Ev0123ABCD');
+  });
+
+  it('canonicalizes a bare-channel mention by promoting message_ts to thread_ts', () => {
+    const env = buildEnvelope();
+    const eventNoThread = { ...env.event };
+    delete (eventNoThread as { thread_ts?: string }).thread_ts;
+    const incoming = mapAppMentionToIncomingEvent({ ...env, event: eventNoThread });
+
+    expect(incoming.channelNativeRef).toBe('slack:C9876CHAN:1700000123.000200');
+    expect(incoming.threading).toMatchObject({
+      message_ts: '1700000123.000200',
+      thread_ts: '1700000123.000200',
+    });
+  });
+
+  it('parses receivedAt from event_ts in seconds', () => {
+    const incoming = mapAppMentionToIncomingEvent(buildEnvelope({ event_ts: '1700000456.789000' }));
+    expect(incoming.receivedAt.getTime()).toBe(1700000456789);
+  });
+
+  it('passes empty text through when event.text is missing', () => {
+    const env = buildEnvelope();
+    const eventNoText = { ...env.event };
+    delete (eventNoText as { text?: string }).text;
+    const incoming = mapAppMentionToIncomingEvent({ ...env, event: eventNoText });
+    expect(incoming.payload.text).toBe('');
+  });
+
+  it('throws SlackEventMappingError when event.user is missing', () => {
+    const env = buildEnvelope();
+    const eventNoUser = { ...env.event };
+    delete (eventNoUser as { user?: string }).user;
+    expect(() => mapAppMentionToIncomingEvent({ ...env, event: eventNoUser })).toThrow(
+      SlackEventMappingError,
+    );
+  });
+});

--- a/packages/adapter-channel-slack/src/slack-event-mapping.ts
+++ b/packages/adapter-channel-slack/src/slack-event-mapping.ts
@@ -1,0 +1,55 @@
+import type { IncomingEvent } from '@agentry/core';
+import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
+
+// Subset of the Slack `app_mention` envelope we depend on. Bolt's published
+// types are looser; this is the contract we read at runtime, so we pin it
+// explicitly.
+export interface SlackAppMentionEnvelope {
+  readonly event: {
+    readonly type: 'app_mention';
+    readonly user?: string;
+    readonly text?: string;
+    readonly ts: string;
+    readonly thread_ts?: string;
+    readonly channel: string;
+    readonly event_ts: string;
+  };
+  readonly event_id: string;
+  readonly team_id: string;
+}
+
+export class SlackEventMappingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SlackEventMappingError';
+  }
+}
+
+// Channel-mention only (DMs are deferred). Self-mention filtering is not
+// applied: `app_mention` is fired only when *someone else* mentions the bot.
+// If a future revision subscribes to `message.channels`, add a self-message
+// filter at that subscription point.
+export function mapAppMentionToIncomingEvent(envelope: SlackAppMentionEnvelope): IncomingEvent {
+  const { event, event_id, team_id } = envelope;
+  if (!event.user) {
+    throw new SlackEventMappingError(
+      `app_mention without event.user (event_id=${event_id}); cannot identify author`,
+    );
+  }
+
+  const threadTs = event.thread_ts ?? event.ts;
+  return {
+    channelKind: SLACK_CHANNEL_KIND,
+    channelNativeRef: `slack:${event.channel}:${threadTs}`,
+    author: { channelUserId: event.user },
+    payload: { text: event.text ?? '' },
+    threading: {
+      channel: event.channel,
+      message_ts: event.ts,
+      thread_ts: threadTs,
+      team_id,
+    },
+    receivedAt: new Date(Number.parseFloat(event.event_ts) * 1000),
+    idempotencyKey: event_id,
+  };
+}

--- a/packages/adapter-channel-slack/src/slack-event-mapping.ts
+++ b/packages/adapter-channel-slack/src/slack-event-mapping.ts
@@ -31,6 +31,14 @@ export class SlackEventMappingError extends Error {
 // filter at that subscription point.
 export function mapAppMentionToIncomingEvent(envelope: SlackAppMentionEnvelope): IncomingEvent {
   const { event, event_id, team_id } = envelope;
+  if (!event_id) {
+    throw new SlackEventMappingError(
+      'app_mention envelope missing event_id (cannot derive idempotencyKey)',
+    );
+  }
+  if (!team_id) {
+    throw new SlackEventMappingError(`app_mention envelope missing team_id (event_id=${event_id})`);
+  }
   if (!event.user) {
     throw new SlackEventMappingError(
       `app_mention without event.user (event_id=${event_id}); cannot identify author`,

--- a/packages/adapter-channel-slack/src/slack-inbound-channel.test.ts
+++ b/packages/adapter-channel-slack/src/slack-inbound-channel.test.ts
@@ -1,0 +1,210 @@
+import type { IncomingEvent, Logger } from '@agentry/core';
+import type { App } from '@slack/bolt';
+import { describe, expect, it, vi } from 'vitest';
+import { SlackInboundChannel } from './slack-inbound-channel.js';
+
+// dep-cruiser forbids adapter-* → @agentry/testing imports (the testing
+// package is wired only into core's use-case tests and runtime). The
+// silentLogger duplication here is the layering tax for keeping adapters
+// self-contained.
+const silentLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => silentLogger,
+};
+
+type AppMentionHandler = (ctx: { event: object; body: object; logger: Logger }) => Promise<void>;
+
+interface FakeAppShape {
+  readonly app: App;
+  readonly captured: { handler?: AppMentionHandler; startPort?: number; stopped: boolean };
+}
+
+function fakeApp(): FakeAppShape {
+  const captured: FakeAppShape['captured'] = { stopped: false };
+  const app = {
+    event: vi.fn().mockImplementation((type: string, h: AppMentionHandler) => {
+      if (type === 'app_mention') captured.handler = h;
+    }),
+    start: vi.fn().mockImplementation(async (port: number) => {
+      captured.startPort = port;
+    }),
+    stop: vi.fn().mockImplementation(async () => {
+      captured.stopped = true;
+    }),
+  } as unknown as App;
+  return { app, captured };
+}
+
+function fakeFetchOk(grantedScopes: string[]): typeof globalThis.fetch {
+  return (async () =>
+    ({
+      headers: {
+        get: (n: string) => (n.toLowerCase() === 'x-oauth-scopes' ? grantedScopes.join(',') : null),
+      },
+      json: async () => ({ ok: true, user_id: 'UBOT', team_id: 'T1' }),
+      ok: true,
+      status: 200,
+    }) as unknown as Response) as typeof globalThis.fetch;
+}
+
+async function waitForHandler(
+  captured: FakeAppShape['captured'],
+): Promise<NonNullable<FakeAppShape['captured']['handler']>> {
+  await vi.waitFor(() => {
+    expect(captured.handler).toBeDefined();
+  });
+  if (!captured.handler) throw new Error('app_mention handler was not registered');
+  return captured.handler;
+}
+
+const baseOpts = {
+  botToken: 'xoxb-test-token',
+  signingSecret: 'sigsecret',
+  port: 3001,
+  requiredScopes: ['app_mentions:read', 'chat:write'],
+};
+
+describe('SlackInboundChannel', () => {
+  it('declares slack channelKind', () => {
+    const ch = new SlackInboundChannel(baseOpts);
+    expect(ch.kind).toBe('slack');
+  });
+
+  it('returns immediately when signal is already aborted, with no side effects', async () => {
+    const { app, captured } = fakeApp();
+    const ac = new AbortController();
+    ac.abort();
+    const ch = new SlackInboundChannel({
+      ...baseOpts,
+      app,
+      fetch: fakeFetchOk(['chat:write']),
+    });
+    await ch.start(async () => {}, ac.signal);
+    expect(captured.startPort).toBeUndefined();
+    expect(captured.handler).toBeUndefined();
+    expect(captured.stopped).toBe(false);
+  });
+
+  it('throws if scope verification fails (missing scope)', async () => {
+    const { app } = fakeApp();
+    const ch = new SlackInboundChannel({
+      ...baseOpts,
+      app,
+      fetch: fakeFetchOk(['chat:write']),
+    });
+    const ac = new AbortController();
+    await expect(ch.start(async () => {}, ac.signal)).rejects.toThrow(/missing required scopes/);
+  });
+
+  it('binds Bolt listener on configured port and registers an app_mention handler', async () => {
+    const { app, captured } = fakeApp();
+    const ch = new SlackInboundChannel({
+      ...baseOpts,
+      app,
+      fetch: fakeFetchOk(['app_mentions:read', 'chat:write']),
+    });
+    const ac = new AbortController();
+    const startPromise = ch.start(async () => {}, ac.signal);
+    await waitForHandler(captured);
+    await vi.waitFor(() => {
+      expect(captured.startPort).toBe(3001);
+    });
+    ac.abort();
+    await startPromise;
+    expect(captured.stopped).toBe(true);
+  });
+
+  it('throws if start() is called twice on the same instance', async () => {
+    const { app, captured } = fakeApp();
+    const ch = new SlackInboundChannel({
+      ...baseOpts,
+      app,
+      fetch: fakeFetchOk(['app_mentions:read', 'chat:write']),
+    });
+    const ac = new AbortController();
+    const first = ch.start(async () => {}, ac.signal);
+    await waitForHandler(captured);
+    await expect(ch.start(async () => {}, ac.signal)).rejects.toThrow(/single-shot/);
+    ac.abort();
+    await first;
+  });
+
+  it('forwards mapped IncomingEvent to handler when app_mention fires', async () => {
+    const { app, captured } = fakeApp();
+    const seen: IncomingEvent[] = [];
+    const ch = new SlackInboundChannel({
+      ...baseOpts,
+      app,
+      fetch: fakeFetchOk(['app_mentions:read', 'chat:write']),
+    });
+    const ac = new AbortController();
+    const startPromise = ch.start(async (e) => {
+      seen.push(e);
+    }, ac.signal);
+    const handler = await waitForHandler(captured);
+
+    await handler({
+      event: {
+        type: 'app_mention',
+        user: 'U1',
+        text: 'hi',
+        ts: '1700000123.000200',
+        thread_ts: '1700000000.000100',
+        channel: 'C9',
+        event_ts: '1700000123.000200',
+      },
+      body: { event_id: 'EvX', team_id: 'T1' },
+      logger: silentLogger,
+    });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      channelKind: 'slack',
+      channelNativeRef: 'slack:C9:1700000000.000100',
+      idempotencyKey: 'EvX',
+    });
+
+    ac.abort();
+    await startPromise;
+  });
+
+  it('logs and swallows handler errors so Bolt still acks the request', async () => {
+    const { app, captured } = fakeApp();
+    const errorLog = vi.fn();
+    const logger: Logger = { ...silentLogger, error: errorLog };
+    const ch = new SlackInboundChannel({
+      ...baseOpts,
+      app,
+      logger,
+      fetch: fakeFetchOk(['app_mentions:read', 'chat:write']),
+    });
+    const ac = new AbortController();
+    const startPromise = ch.start(async () => {
+      throw new Error('boom');
+    }, ac.signal);
+    const handler = await waitForHandler(captured);
+
+    await handler({
+      event: {
+        type: 'app_mention',
+        user: 'U1',
+        text: 'hi',
+        ts: '1.0',
+        thread_ts: '1.0',
+        channel: 'C9',
+        event_ts: '1.0',
+      },
+      body: { event_id: 'EvX', team_id: 'T1' },
+      logger,
+    });
+
+    expect(errorLog).toHaveBeenCalledOnce();
+    ac.abort();
+    await startPromise;
+  });
+});

--- a/packages/adapter-channel-slack/src/slack-inbound-channel.ts
+++ b/packages/adapter-channel-slack/src/slack-inbound-channel.ts
@@ -59,10 +59,11 @@ export class SlackInboundChannel implements InboundChannel {
 
     app.event('app_mention', async ({ event, body, logger }) => {
       try {
+        const b = body as { event_id?: unknown; team_id?: unknown };
         const envelope: SlackAppMentionEnvelope = {
           event: event as SlackAppMentionEnvelope['event'],
-          event_id: (body as { event_id: string }).event_id,
-          team_id: (body as { team_id: string }).team_id,
+          event_id: typeof b.event_id === 'string' ? b.event_id : '',
+          team_id: typeof b.team_id === 'string' ? b.team_id : '',
         };
         const incoming = mapAppMentionToIncomingEvent(envelope);
         await handler(incoming);

--- a/packages/adapter-channel-slack/src/slack-inbound-channel.ts
+++ b/packages/adapter-channel-slack/src/slack-inbound-channel.ts
@@ -1,0 +1,94 @@
+import type { ChannelKind, InboundChannel, IncomingEvent, Logger } from '@agentry/core';
+import { App } from '@slack/bolt';
+import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
+import {
+  mapAppMentionToIncomingEvent,
+  type SlackAppMentionEnvelope,
+} from './slack-event-mapping.js';
+import { verifySlackScopes } from './slack-scope-verifier.js';
+
+// Required for receiving channel mentions and replying (excludes thread
+// backfill scopes — those belong to PR2 when the backfill path lands).
+export const SLACK_REQUIRED_SCOPES_PR1: readonly string[] = ['app_mentions:read', 'chat:write'];
+
+export interface SlackInboundChannelOptions {
+  readonly botToken: string;
+  readonly signingSecret: string;
+  readonly port: number;
+  readonly logger?: Logger;
+  // Test seams: inject pre-built App / fetch so unit tests skip Bolt's HTTP
+  // listener and the real Slack auth.test call.
+  readonly app?: App;
+  readonly fetch?: typeof globalThis.fetch;
+  readonly requiredScopes?: readonly string[];
+}
+
+export class SlackInboundChannel implements InboundChannel {
+  readonly kind: ChannelKind = SLACK_CHANNEL_KIND;
+  private readonly opts: SlackInboundChannelOptions;
+  private started = false;
+
+  constructor(opts: SlackInboundChannelOptions) {
+    this.opts = opts;
+  }
+
+  async start(
+    handler: (event: IncomingEvent) => Promise<void>,
+    signal: AbortSignal,
+  ): Promise<void> {
+    // Single-shot: a second call would register a duplicate `app_mention`
+    // listener on the same App, doubling every event. Composition root must
+    // build a new instance per restart.
+    if (this.started) {
+      throw new Error(
+        'SlackInboundChannel.start() is single-shot; create a new instance to restart',
+      );
+    }
+    this.started = true;
+    if (signal.aborted) return;
+
+    const required = this.opts.requiredScopes ?? SLACK_REQUIRED_SCOPES_PR1;
+    await verifySlackScopes(this.opts.botToken, required, this.opts.fetch);
+
+    const app =
+      this.opts.app ??
+      new App({
+        token: this.opts.botToken,
+        signingSecret: this.opts.signingSecret,
+      });
+
+    app.event('app_mention', async ({ event, body, logger }) => {
+      try {
+        const envelope: SlackAppMentionEnvelope = {
+          event: event as SlackAppMentionEnvelope['event'],
+          event_id: (body as { event_id: string }).event_id,
+          team_id: (body as { team_id: string }).team_id,
+        };
+        const incoming = mapAppMentionToIncomingEvent(envelope);
+        await handler(incoming);
+      } catch (err) {
+        // Log and swallow: failing here would cause Bolt to leave the request
+        // un-acked, prompting Slack to redeliver (idempotency handles the
+        // dup but we'd burn time on every redelivery). Errors after enqueue
+        // are the JobRunner's concern.
+        const log = this.opts.logger ?? logger;
+        log.error({ err }, 'slack app_mention handling failed');
+      }
+    });
+
+    // app.start(port) binds the HTTP listener and resolves immediately.
+    // The InboundChannel contract requires start() to resolve only when
+    // listening stops, so we await an abort-driven promise before stopping.
+    await app.start(this.opts.port);
+
+    await new Promise<void>((resolve) => {
+      if (signal.aborted) {
+        resolve();
+        return;
+      }
+      signal.addEventListener('abort', () => resolve(), { once: true });
+    });
+
+    await app.stop();
+  }
+}

--- a/packages/adapter-channel-slack/src/slack-outbound-channel.test.ts
+++ b/packages/adapter-channel-slack/src/slack-outbound-channel.test.ts
@@ -1,0 +1,87 @@
+import type { ReplyTarget } from '@agentry/core';
+import type { WebClient } from '@slack/web-api';
+import { describe, expect, it, vi } from 'vitest';
+import { SlackOutboundChannel, SlackOutboundChannelError } from './slack-outbound-channel.js';
+
+interface PostMessageArgs {
+  readonly channel: string;
+  readonly thread_ts?: string;
+  readonly text: string;
+}
+
+function fakeClient(
+  postMessage: (args: PostMessageArgs) => Promise<{ ok: boolean; ts?: string; error?: string }>,
+): WebClient {
+  return {
+    chat: {
+      postMessage: vi.fn().mockImplementation(postMessage),
+    },
+  } as unknown as WebClient;
+}
+
+const target: ReplyTarget = {
+  channelKind: 'slack',
+  channelNativeRef: 'slack:C9876:1700000000.000100',
+  threading: {
+    channel: 'C9876',
+    thread_ts: '1700000000.000100',
+    message_ts: '1700000123.000200',
+  },
+};
+
+describe('SlackOutboundChannel', () => {
+  it('declares slack channelKind', () => {
+    const ch = new SlackOutboundChannel({
+      botToken: 'xoxb-x',
+      client: fakeClient(async () => ({ ok: true, ts: '1.0' })),
+    });
+    expect(ch.kind).toBe('slack');
+  });
+
+  it('calls chat.postMessage with channel + thread_ts + text', async () => {
+    const seen: PostMessageArgs[] = [];
+    const client = fakeClient(async (args) => {
+      seen.push(args);
+      return { ok: true, ts: '1700000456.789000' };
+    });
+    const ch = new SlackOutboundChannel({ botToken: 'xoxb-x', client });
+    const ack = await ch.reply(target, { text: 'hello' });
+
+    expect(seen).toEqual([{ channel: 'C9876', thread_ts: '1700000000.000100', text: 'hello' }]);
+    expect(ack.messageId).toBe('1700000456.789000');
+    expect(ack.postedAt.getTime()).toBe(1700000456789);
+    expect(ack.metadata).toEqual({ channel: 'C9876', thread_ts: '1700000000.000100' });
+  });
+
+  it('throws SlackOutboundChannelError when threading is incomplete', async () => {
+    const ch = new SlackOutboundChannel({
+      botToken: 'xoxb-x',
+      client: fakeClient(async () => ({ ok: true, ts: '1.0' })),
+    });
+    const incomplete: ReplyTarget = {
+      channelKind: 'slack',
+      channelNativeRef: 'slack:C9876:1.0',
+      threading: { channel: 'C9876' },
+    };
+    await expect(ch.reply(incomplete, { text: 'hi' })).rejects.toThrow(SlackOutboundChannelError);
+  });
+
+  it('propagates Slack API errors via SlackOutboundChannelError', async () => {
+    const ch = new SlackOutboundChannel({
+      botToken: 'xoxb-x',
+      client: fakeClient(async () => ({ ok: false, error: 'channel_not_found' })),
+    });
+    await expect(ch.reply(target, { text: 'hi' })).rejects.toMatchObject({
+      name: 'SlackOutboundChannelError',
+      message: expect.stringContaining('channel_not_found'),
+    });
+  });
+
+  it('throws when response is missing ts even with ok:true', async () => {
+    const ch = new SlackOutboundChannel({
+      botToken: 'xoxb-x',
+      client: fakeClient(async () => ({ ok: true })),
+    });
+    await expect(ch.reply(target, { text: 'hi' })).rejects.toThrow(SlackOutboundChannelError);
+  });
+});

--- a/packages/adapter-channel-slack/src/slack-outbound-channel.ts
+++ b/packages/adapter-channel-slack/src/slack-outbound-channel.ts
@@ -1,0 +1,65 @@
+import type {
+  ChannelKind,
+  OutboundChannel,
+  ReplyAck,
+  ReplyContent,
+  ReplyTarget,
+} from '@agentry/core';
+import { WebClient } from '@slack/web-api';
+import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
+
+export interface SlackOutboundChannelOptions {
+  readonly botToken: string;
+  // Test seam: inject a pre-built WebClient (used by unit tests with mocked
+  // chat.postMessage). When omitted, the constructor builds one from token.
+  readonly client?: WebClient;
+}
+
+interface SlackThreadingShape {
+  readonly channel?: unknown;
+  readonly thread_ts?: unknown;
+}
+
+export class SlackOutboundChannelError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SlackOutboundChannelError';
+  }
+}
+
+export class SlackOutboundChannel implements OutboundChannel {
+  readonly kind: ChannelKind = SLACK_CHANNEL_KIND;
+  private readonly client: WebClient;
+
+  constructor(opts: SlackOutboundChannelOptions) {
+    this.client = opts.client ?? new WebClient(opts.botToken);
+  }
+
+  async reply(target: ReplyTarget, content: ReplyContent): Promise<ReplyAck> {
+    const threading = (target.threading ?? {}) as SlackThreadingShape;
+    const channel = typeof threading.channel === 'string' ? threading.channel : undefined;
+    const threadTs = typeof threading.thread_ts === 'string' ? threading.thread_ts : undefined;
+    if (!channel || !threadTs) {
+      throw new SlackOutboundChannelError(
+        `Slack reply requires threading.channel and threading.thread_ts; got ${JSON.stringify(threading)}`,
+      );
+    }
+
+    const result = await this.client.chat.postMessage({
+      channel,
+      thread_ts: threadTs,
+      text: content.text,
+    });
+    if (!result.ok || !result.ts) {
+      throw new SlackOutboundChannelError(
+        `chat.postMessage failed: ${result.error ?? 'response missing ts'}`,
+      );
+    }
+
+    return {
+      messageId: result.ts,
+      postedAt: new Date(Number.parseFloat(result.ts) * 1000),
+      metadata: { channel, thread_ts: threadTs },
+    };
+  }
+}

--- a/packages/adapter-channel-slack/src/slack-scope-verifier.test.ts
+++ b/packages/adapter-channel-slack/src/slack-scope-verifier.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { SlackScopeError, verifySlackScopes } from './slack-scope-verifier.js';
+
+interface FakeAuthTestArgs {
+  readonly grantedHeader: string | null;
+  readonly body: object;
+  readonly status?: number;
+}
+
+function fakeFetch({
+  grantedHeader,
+  body,
+  status = 200,
+}: FakeAuthTestArgs): typeof globalThis.fetch {
+  return (async (_input: unknown, init?: RequestInit) => {
+    const auth = init?.headers && (init.headers as Record<string, string>).Authorization;
+    if (auth !== 'Bearer xoxb-test-token') {
+      throw new Error(`Unexpected Authorization header: ${String(auth)}`);
+    }
+    return {
+      headers: {
+        get: (name: string) => (name.toLowerCase() === 'x-oauth-scopes' ? grantedHeader : null),
+      },
+      json: async () => body,
+      ok: status >= 200 && status < 300,
+      status,
+    } as unknown as Response;
+  }) as typeof globalThis.fetch;
+}
+
+describe('verifySlackScopes', () => {
+  it('returns auth info when all required scopes are granted', async () => {
+    const fetch = fakeFetch({
+      grantedHeader: 'app_mentions:read,chat:write,channels:history',
+      body: { ok: true, user_id: 'UBOT', team_id: 'T1' },
+    });
+    const info = await verifySlackScopes(
+      'xoxb-test-token',
+      ['app_mentions:read', 'chat:write'],
+      fetch,
+    );
+    expect(info).toEqual({
+      botUserId: 'UBOT',
+      teamId: 'T1',
+      grantedScopes: ['app_mentions:read', 'chat:write', 'channels:history'],
+    });
+  });
+
+  it('throws SlackScopeError listing every missing scope', async () => {
+    const fetch = fakeFetch({
+      grantedHeader: 'chat:write',
+      body: { ok: true, user_id: 'UBOT', team_id: 'T1' },
+    });
+    await expect(
+      verifySlackScopes(
+        'xoxb-test-token',
+        ['app_mentions:read', 'chat:write', 'channels:history'],
+        fetch,
+      ),
+    ).rejects.toMatchObject({
+      name: 'SlackScopeError',
+      message: expect.stringContaining('[app_mentions:read, channels:history]'),
+    });
+  });
+
+  it('throws when auth.test returns ok:false', async () => {
+    const fetch = fakeFetch({
+      grantedHeader: 'chat:write',
+      body: { ok: false, error: 'invalid_auth' },
+    });
+    await expect(verifySlackScopes('xoxb-test-token', [], fetch)).rejects.toThrow(SlackScopeError);
+  });
+
+  it('throws when response is missing user_id or team_id', async () => {
+    const fetch = fakeFetch({
+      grantedHeader: 'chat:write',
+      body: { ok: true },
+    });
+    await expect(verifySlackScopes('xoxb-test-token', [], fetch)).rejects.toThrow(SlackScopeError);
+  });
+
+  it('treats absent x-oauth-scopes header as empty grant', async () => {
+    const fetch = fakeFetch({
+      grantedHeader: null,
+      body: { ok: true, user_id: 'UBOT', team_id: 'T1' },
+    });
+    await expect(verifySlackScopes('xoxb-test-token', ['chat:write'], fetch)).rejects.toThrow(
+      SlackScopeError,
+    );
+  });
+});

--- a/packages/adapter-channel-slack/src/slack-scope-verifier.ts
+++ b/packages/adapter-channel-slack/src/slack-scope-verifier.ts
@@ -1,0 +1,63 @@
+// Slack OAuth scope verifier. Bolt's WebClient does not expose response
+// headers, but every Web API response carries `x-oauth-scopes` listing the
+// granted scopes (per https://docs.slack.dev/authentication/installing-with-oauth).
+// We therefore make a raw fetch against `auth.test` to read both the granted
+// scopes and the bot identity in one call.
+
+const SLACK_AUTH_TEST_URL = 'https://slack.com/api/auth.test';
+
+export interface SlackAuthInfo {
+  readonly botUserId: string;
+  readonly teamId: string;
+  readonly grantedScopes: readonly string[];
+}
+
+export class SlackScopeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SlackScopeError';
+  }
+}
+
+interface AuthTestBody {
+  readonly ok: boolean;
+  readonly user_id?: string;
+  readonly team_id?: string;
+  readonly error?: string;
+}
+
+export async function verifySlackScopes(
+  botToken: string,
+  required: readonly string[],
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+): Promise<SlackAuthInfo> {
+  const res = await fetchImpl(SLACK_AUTH_TEST_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${botToken}` },
+  });
+  const grantedHeader = res.headers.get('x-oauth-scopes') ?? '';
+  const grantedScopes = grantedHeader
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const body = (await res.json()) as AuthTestBody;
+  if (!body.ok) {
+    throw new SlackScopeError(`Slack auth.test failed: ${body.error ?? 'unknown error'}`);
+  }
+  if (!body.user_id || !body.team_id) {
+    throw new SlackScopeError('Slack auth.test response missing user_id or team_id');
+  }
+
+  const granted = new Set(grantedScopes);
+  const missing = required.filter((s) => !granted.has(s));
+  if (missing.length > 0) {
+    throw new SlackScopeError(
+      `Slack bot token is missing required scopes: [${missing.join(', ')}]. ` +
+        'Reinstall the app at https://api.slack.com/apps and grant the missing scopes, ' +
+        'then update SLACK_BOT_TOKEN.',
+    );
+  }
+
+  return { botUserId: body.user_id, teamId: body.team_id, grantedScopes };
+}

--- a/packages/adapter-channel-slack/src/slack-session-policy.test.ts
+++ b/packages/adapter-channel-slack/src/slack-session-policy.test.ts
@@ -1,0 +1,42 @@
+import type { IncomingEvent, SessionLifecycleEvent } from '@agentry/core';
+import { describe, expect, it } from 'vitest';
+import { SlackSessionPolicy } from './slack-session-policy.js';
+
+function buildEvent(channelNativeRef: string): IncomingEvent {
+  return {
+    channelKind: 'slack',
+    channelNativeRef,
+    author: { channelUserId: 'U1' },
+    payload: { text: 'hi' },
+    threading: { channel: 'C1', thread_ts: '1.0', message_ts: '1.0', team_id: 'T1' },
+    receivedAt: new Date(0),
+    idempotencyKey: 'Ev1',
+  };
+}
+
+describe('SlackSessionPolicy', () => {
+  const policy = new SlackSessionPolicy();
+
+  it('declares slack channelKind', () => {
+    expect(policy.channelKind).toBe('slack');
+  });
+
+  it('returns the canonical nativeRef from the IncomingEvent (identity)', () => {
+    expect(policy.computeNativeRef(buildEvent('slack:C1:1.0'))).toBe('slack:C1:1.0');
+    expect(policy.computeNativeRef(buildEvent('slack:CXY:9.7'))).toBe('slack:CXY:9.7');
+  });
+
+  it('returns 24h idle timeout per ARCH §4.3', () => {
+    expect(policy.idleTimeoutMinutes()).toBe(1440);
+  });
+
+  it('ends session on channel_close', () => {
+    const closed: SessionLifecycleEvent = { kind: 'channel_close' };
+    expect(policy.shouldEndOn(closed)).toBe(true);
+  });
+
+  it('does not end session on idle_timeout or other kinds', () => {
+    expect(policy.shouldEndOn({ kind: 'idle_timeout' })).toBe(false);
+    expect(policy.shouldEndOn({ kind: 'user_left' })).toBe(false);
+  });
+});

--- a/packages/adapter-channel-slack/src/slack-session-policy.ts
+++ b/packages/adapter-channel-slack/src/slack-session-policy.ts
@@ -1,0 +1,30 @@
+import type {
+  ChannelKind,
+  ChannelNativeRef,
+  IncomingEvent,
+  SessionLifecycleEvent,
+  SessionPolicy,
+} from '@agentry/core';
+import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
+
+// 24h idle window per ARCHITECTURE.md §4.3.
+const SLACK_IDLE_TIMEOUT_MIN = 24 * 60;
+
+export class SlackSessionPolicy implements SessionPolicy {
+  readonly channelKind: ChannelKind = SLACK_CHANNEL_KIND;
+
+  // mapAppMentionToIncomingEvent already produces the canonical
+  // `slack:${channel}:${ts}` form; the policy is identity (matches the
+  // StaticSessionPolicy convention).
+  computeNativeRef(event: IncomingEvent): ChannelNativeRef {
+    return event.channelNativeRef;
+  }
+
+  idleTimeoutMinutes(): number {
+    return SLACK_IDLE_TIMEOUT_MIN;
+  }
+
+  shouldEndOn(event: SessionLifecycleEvent): boolean {
+    return event.kind === 'channel_close';
+  }
+}

--- a/packages/adapter-channel-slack/tsconfig.json
+++ b/packages/adapter-channel-slack/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/testing/src/app/handle-incoming-message.test.ts
+++ b/packages/testing/src/app/handle-incoming-message.test.ts
@@ -5,7 +5,6 @@ import type {
   ChannelKind,
   HandleIncomingMessageDeps,
   IncomingEvent,
-  Logger,
   OutboundChannel,
   SessionPolicy,
 } from '@agentry/core';
@@ -15,6 +14,7 @@ import { RecordingAgentRunner } from '../agent-runner/recording-agent-runner.js'
 import { RecordingOutboundChannel } from '../channels/recording-outbound-channel.js';
 import { InMemoryJobRunner } from '../job-runner/in-memory-job-runner.js';
 import { InMemoryKnowledgeStore } from '../knowledge-store/in-memory-knowledge-store.js';
+import { silentLogger } from '../logger/silent-logger.js';
 import { StaticSessionPolicy } from '../session-policy/static-session-policy.js';
 import { InMemorySessionStore } from '../session-store/in-memory-session-store.js';
 
@@ -29,16 +29,6 @@ function deferred<T>(): Deferred<T> {
   });
   return { promise, resolve };
 }
-
-const silentLogger: Logger = {
-  trace: () => {},
-  debug: () => {},
-  info: () => {},
-  warn: () => {},
-  error: () => {},
-  fatal: () => {},
-  child: () => silentLogger,
-};
 
 function makeEvent(overrides: Partial<IncomingEvent> = {}): IncomingEvent {
   return {

--- a/packages/testing/src/index.ts
+++ b/packages/testing/src/index.ts
@@ -6,6 +6,7 @@ export { RecordingOutboundChannel } from './channels/recording-outbound-channel.
 export type { InMemoryJobRunnerOptions } from './job-runner/in-memory-job-runner.js';
 export { InMemoryJobRunner } from './job-runner/in-memory-job-runner.js';
 export { InMemoryKnowledgeStore } from './knowledge-store/in-memory-knowledge-store.js';
+export { silentLogger } from './logger/silent-logger.js';
 export type { StaticSessionPolicyOptions } from './session-policy/static-session-policy.js';
 export { StaticSessionPolicy } from './session-policy/static-session-policy.js';
 export { InMemorySessionStore } from './session-store/in-memory-session-store.js';

--- a/packages/testing/src/logger/silent-logger.ts
+++ b/packages/testing/src/logger/silent-logger.ts
@@ -1,0 +1,11 @@
+import type { Logger } from '@agentry/core';
+
+export const silentLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => silentLogger,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,22 @@ importers:
         specifier: ^24.0.0
         version: 24.12.2
 
+  packages/adapter-channel-slack:
+    dependencies:
+      '@agentry/core':
+        specifier: workspace:*
+        version: link:../core
+      '@slack/bolt':
+        specifier: ^4.7.1
+        version: 4.7.1(@types/express@5.0.6)
+      '@slack/web-api':
+        specifier: ^7.15.1
+        version: 7.15.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.2
+        version: 24.12.2
+
   packages/adapter-embedding-voyage:
     dependencies:
       '@agentry/core':
@@ -583,14 +599,46 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.17':
     resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
+  '@slack/bolt@4.7.1':
+    resolution: {integrity: sha512-CIyVjvHm/gY/e6n/xsJibcQFh2+S0WrlaV4LzpwXDlsmWuDrhLzAqBcOP/i9vgyFklO+DXD9Pzbz2uSPCctnZQ==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+    peerDependencies:
+      '@types/express': ^5.0.0
+
+  '@slack/logger@4.0.1':
+    resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/oauth@3.0.5':
+    resolution: {integrity: sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+
+  '@slack/socket-mode@2.0.6':
+    resolution: {integrity: sha512-Aj5RO3MoYVJ+b2tUjHUXuA3tiIaCUMOf1Ss5tPiz29XYVUi6qNac2A8ulcU1pUPERpXVHTmT1XW6HzQIO74daQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/types@2.20.1':
+    resolution: {integrity: sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.15.1':
+    resolution: {integrity: sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -604,6 +652,21 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
@@ -616,6 +679,21 @@ packages:
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
+  '@types/qs@6.15.0':
+    resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
   '@types/ssh2-streams@0.1.13':
     resolution: {integrity: sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==}
 
@@ -624,6 +702,9 @@ packages:
 
   '@types/ssh2@1.15.5':
     resolution: {integrity: sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -657,6 +738,10 @@ packages:
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
 
   acorn-jsx-walk@2.0.0:
     resolution: {integrity: sha512-uuo6iJj4D4ygkdzd6jPtcxs8vZgDX9YFIkqczGImoypX2fQ4dVImmu3UzA4ynixCIMTrEOWW+95M2HuBaCEOVA==}
@@ -716,9 +801,15 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
+
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -781,12 +872,19 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -801,6 +899,18 @@ packages:
   byline@5.0.0:
     resolution: {integrity: sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==}
     engines: {node: '>=0.10.0'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -824,6 +934,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
@@ -832,8 +946,24 @@ packages:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -864,6 +994,14 @@ packages:
       supports-color:
         optional: true
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dependency-cruiser@17.3.10:
     resolution: {integrity: sha512-jF5WaIb+O+wLabXrQE7iBY2zYBEW8VlnuuL0+iZPvZHGhTaAYdLk31DI0zkwhcGE8CiHcDwGhMnn3PfOAYnVdQ==}
     engines: {node: ^20.12||^22||>=24}
@@ -885,14 +1023,28 @@ packages:
     resolution: {integrity: sha512-/bCZd6KlGcjZO8Buqmi/vXuqEGVEZ0PNjx/biBNqJD3MhK9DmdiAuKxqfNhflgDESDIiBz3qF+0e55+CpnrUcw==}
     engines: {node: '>= 8.0'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -901,12 +1053,24 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -917,12 +1081,25 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -934,6 +1111,10 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -947,9 +1128,34 @@ packages:
       picomatch:
         optional: true
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -966,9 +1172,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-port@7.2.0:
     resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
     engines: {node: '>=16'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -982,12 +1196,24 @@ packages:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
@@ -996,6 +1222,14 @@ packages:
   hono@4.12.15:
     resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1015,9 +1249,16 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
+
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -1030,6 +1271,9 @@ packages:
   is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -1048,6 +1292,16 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -1134,6 +1388,27 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -1145,6 +1420,34 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   minimatch@5.1.9:
     resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
@@ -1180,9 +1483,17 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1191,11 +1502,35 @@ packages:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
 
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1207,6 +1542,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1307,11 +1645,31 @@ packages:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -1355,10 +1713,18 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rolldown@1.0.0-rc.17:
     resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -1381,6 +1747,17 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1388,6 +1765,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1425,6 +1818,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -1515,6 +1912,10 @@ packages:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
     engines: {node: '>=14.14'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
     engines: {node: '>=10.13.0'}
@@ -1526,6 +1927,10 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsscmp@1.0.6:
+    resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
+    engines: {node: '>=0.6.x'}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -1533,6 +1938,10 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -1552,12 +1961,20 @@ packages:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -1668,6 +2085,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -1960,6 +2389,71 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.17': {}
 
+  '@slack/bolt@4.7.1(@types/express@5.0.6)':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/oauth': 3.0.5
+      '@slack/socket-mode': 2.0.6
+      '@slack/types': 2.20.1
+      '@slack/web-api': 7.15.1
+      '@types/express': 5.0.6
+      axios: 1.15.2
+      express: 5.2.1
+      path-to-regexp: 8.4.2
+      raw-body: 3.0.2
+      tsscmp: 1.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@slack/logger@4.0.1':
+    dependencies:
+      '@types/node': 24.12.2
+
+  '@slack/oauth@3.0.5':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/web-api': 7.15.1
+      '@types/jsonwebtoken': 9.0.10
+      '@types/node': 24.12.2
+      jsonwebtoken: 9.0.3
+    transitivePeerDependencies:
+      - debug
+
+  '@slack/socket-mode@2.0.6':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/web-api': 7.15.1
+      '@types/node': 24.12.2
+      '@types/ws': 8.18.1
+      eventemitter3: 5.0.4
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@slack/types@2.20.1': {}
+
+  '@slack/web-api@7.15.1':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/types': 2.20.1
+      '@types/node': 24.12.2
+      '@types/retry': 0.12.0
+      axios: 1.15.2
+      eventemitter3: 5.0.4
+      form-data: 4.0.5
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
@@ -1967,10 +2461,19 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 24.12.2
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 24.12.2
 
   '@types/deep-eql@4.0.2': {}
 
@@ -1986,6 +2489,28 @@ snapshots:
       '@types/ssh2': 1.15.5
 
   '@types/estree@1.0.8': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 24.12.2
+      '@types/qs': 6.15.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 24.12.2
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@18.19.130':
     dependencies:
@@ -2005,6 +2530,21 @@ snapshots:
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
+  '@types/qs@6.15.0': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/retry@0.12.0': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 24.12.2
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 24.12.2
+
   '@types/ssh2-streams@0.1.13':
     dependencies:
       '@types/node': 24.12.2
@@ -2017,6 +2557,10 @@ snapshots:
   '@types/ssh2@1.15.5':
     dependencies:
       '@types/node': 18.19.130
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.12.2
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -2062,6 +2606,11 @@ snapshots:
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
 
   acorn-jsx-walk@2.0.0: {}
 
@@ -2123,7 +2672,17 @@ snapshots:
 
   async@3.2.6: {}
 
+  asynckit@0.4.0: {}
+
   atomic-sleep@1.0.0: {}
+
+  axios@1.15.2:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
 
   b4a@1.8.0: {}
 
@@ -2173,11 +2732,27 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 3.0.2
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
 
   buffer-crc32@1.0.0: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer@5.7.1:
     dependencies:
@@ -2193,6 +2768,18 @@ snapshots:
     optional: true
 
   byline@5.0.0: {}
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   chai@6.2.2: {}
 
@@ -2215,6 +2802,10 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@14.0.3: {}
 
   compress-commons@6.0.2:
@@ -2225,7 +2816,15 @@ snapshots:
       normalize-path: 3.0.0
       readable-stream: 4.7.0
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   core-util-is@1.0.3: {}
 
@@ -2251,6 +2850,10 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
 
   dependency-cruiser@17.3.10:
     dependencies:
@@ -2300,11 +2903,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  ee-first@1.1.1: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -2315,9 +2932,22 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -2350,11 +2980,19 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
+
+  eventemitter3@4.0.7: {}
+
+  eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -2366,16 +3004,74 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   fast-fifo@1.3.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  follow-redirects@1.16.0: {}
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -2386,7 +3082,25 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
   get-port@7.2.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -2405,15 +3119,35 @@ snapshots:
     dependencies:
       ini: 4.1.1
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
   hono@4.12.15: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ieee754@1.2.1: {}
 
@@ -2425,9 +3159,13 @@ snapshots:
 
   interpret@3.1.1: {}
 
+  ipaddr.js@1.9.1: {}
+
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.3
+
+  is-electron@2.2.2: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -2437,6 +3175,8 @@ snapshots:
       is-path-inside: 4.0.0
 
   is-path-inside@4.0.0: {}
+
+  is-promise@4.0.0: {}
 
   is-stream@2.0.1: {}
 
@@ -2451,6 +3191,30 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   json5@2.2.3: {}
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   kleur@3.0.3: {}
 
@@ -2509,6 +3273,20 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.once@4.1.1: {}
+
   lodash@4.18.1: {}
 
   long@5.3.2: {}
@@ -2518,6 +3296,24 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   minimatch@5.1.9:
     dependencies:
@@ -2542,17 +3338,43 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
   normalize-path@3.0.0: {}
+
+  object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
 
   on-exit-leak-free@2.1.2: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
 
+  p-finally@1.0.0: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
   package-json-from-dist@1.0.1: {}
+
+  parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
 
@@ -2562,6 +3384,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -2679,12 +3503,32 @@ snapshots:
       '@types/node': 24.12.2
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  proxy-from-env@2.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   readable-stream@2.3.8:
     dependencies:
@@ -2735,6 +3579,8 @@ snapshots:
 
   retry@0.12.0: {}
 
+  retry@0.13.1: {}
+
   rolldown@1.0.0-rc.17:
     dependencies:
       '@oxc-project/types': 0.127.0
@@ -2756,6 +3602,16 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -2770,11 +3626,66 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -2808,6 +3719,8 @@ snapshots:
       nan: 2.26.2
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.1.0: {}
 
@@ -2949,6 +3862,8 @@ snapshots:
 
   tmp@0.2.5: {}
 
+  toidentifier@1.0.1: {}
+
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
@@ -2965,6 +3880,8 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsscmp@1.0.6: {}
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.7
@@ -2973,6 +3890,12 @@ snapshots:
       fsevents: 2.3.3
 
   tweetnacl@0.14.5: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@6.0.3: {}
 
@@ -2984,9 +3907,13 @@ snapshots:
 
   undici@7.25.0: {}
 
+  unpipe@1.0.0: {}
+
   util-deprecate@1.0.2: {}
 
   uuid@10.0.0: {}
+
+  vary@1.1.2: {}
 
   vite@8.0.10(@types/node@24.12.2)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -3053,6 +3980,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   xtend@4.0.2: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
       "@agentry/adapter-jobrunner-memory": ["packages/adapter-jobrunner-memory/src/index.ts"],
       "@agentry/adapter-store-pgvector": ["packages/adapter-store-pgvector/src/index.ts"],
       "@agentry/adapter-embedding-voyage": ["packages/adapter-embedding-voyage/src/index.ts"],
-      "@agentry/adapter-logger-pino": ["packages/adapter-logger-pino/src/index.ts"]
+      "@agentry/adapter-logger-pino": ["packages/adapter-logger-pino/src/index.ts"],
+      "@agentry/adapter-channel-slack": ["packages/adapter-channel-slack/src/index.ts"]
     }
   },
   "files": [],
@@ -22,6 +23,7 @@
     { "path": "packages/adapter-store-pgvector" },
     { "path": "packages/adapter-embedding-voyage" },
     { "path": "packages/adapter-logger-pino" },
+    { "path": "packages/adapter-channel-slack" },
     { "path": "apps/server" },
     { "path": "apps/cli" }
   ]


### PR DESCRIPTION
## Summary

PR1 of two for #18. Ships the adapter package in isolation: 3 ports + Bolt setup + scope verification + unit tests. apps/server wiring + synthetic-history backfill follow in PR2.

This PR does **not** close #18 — checks the first task-list box only. PR2 closes it.

## What's in here

### `packages/adapter-channel-slack/` (new)

- **`SlackInboundChannel`** (InboundChannel port) — wraps `@slack/bolt` 4.7.x. Bolt's HTTP receiver runs on a separate port (option `(a)` from #18 planning); `apps/server` Hono on `:3000` keeps `/health` only. `start()` pattern:
  1. abort short-circuit
  2. scope verification (fail fast)
  3. register `app_mention` handler
  4. `app.start(port)` (binds listener)
  5. await abort-driven promise (InboundChannel contract requires `start()` to resolve when listening *stops*, not when the listener binds)
  6. `app.stop()`

  `start()` is single-shot — calling twice would register a duplicate `app_mention` listener on an injected `App`, doubling every event. Composition root must build a new instance to restart.

- **`SlackOutboundChannel`** (OutboundChannel port) — `chat.postMessage({ channel, thread_ts, text })`. Returns `ReplyAck { messageId: ts, postedAt, metadata }`. Throws `SlackOutboundChannelError` on Slack API failures or incomplete `target.threading`.

- **`SlackSessionPolicy`** (SessionPolicy port) — declares `channelKind = 'slack'`, `idleTimeoutMinutes = 1440` (ARCH §4.3), `shouldEndOn` returns true on `'channel_close'`. `computeNativeRef` is identity: the mapping function produces the canonical `slack:${channel}:${thread_ts ?? message_ts}` form so the policy stays predictable (matches the `StaticSessionPolicy` convention from #58).

- **`mapAppMentionToIncomingEvent`** — pure mapper. `idempotencyKey` from Slack `event_id`. Bare-channel mentions canonicalize `thread_ts = message_ts` so OutboundChannel always has a valid thread. Validates `event_id`/`team_id`/`event.user` at the mapping boundary; throws `SlackEventMappingError` on missing fields.

- **`verifySlackScopes`** — raw `fetch` against `auth.test`, reads granted scopes from the `x-oauth-scopes` HTTP header (Bolt's WebClient does not expose response headers cleanly). Required scopes for PR1: `app_mentions:read`, `chat:write`. Thread-history scopes belong to PR2 with the backfill path. Throws `SlackScopeError` with actionable remediation message per ARCH §4.3.

### Side-house cleanup
- `silentLogger` lifted from `packages/testing/src/app/handle-incoming-message.test.ts` to `packages/testing/src/logger/silent-logger.ts`. Within-testing dedup only — adapter tests keep a local copy because dep-cruiser blocks `adapter-* → @agentry/testing` imports (intentional layering).
- `CLAUDE.md` directory layout: `adapter-channel-slack/  # to be added in #18` → annotation reflecting it now exists.

## Decisions worth flagging

- **Self-mention filter dropped.** The prep memo flagged "filter the bot's own messages" as a pinned design choice. After verification: `app_mention` only fires when *someone else* mentions the bot, never when the bot itself sends messages. The advisor caught this — no filter needed. If a future PR subscribes to `message.channels` (always-listening mode, ARCH §4.3 Phase 2+), add filtering at that subscription point.
- **`App` from `@slack/bolt` leaks through `SlackInboundChannelOptions`.** Test seam (`opts.app` for unit tests). Borderline judgment call — accepted because narrowing to a `BoltAppLike` shim adds surface for marginal isolation.
- **Three new error classes (`SlackScopeError`, `SlackOutboundChannelError`, `SlackEventMappingError`)** — divergence from earlier adapters which `throw new Error(...)`. Justified for a user-facing channel adapter where retry logic may want `instanceof` checks.

## Out of scope (PR2 follow-up)

- Synthetic-history backfill (`conversations.replies` on first-touch threads with unseen `ts`s)
- `apps/server/main.ts` registry wiring
- Integration tests against a Slack-mocking harness (`channels:history` / `groups:history` scopes added then)
- DM support (`slack-dm:` keying) — deferred entirely to a followup

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (9 infos, 0 errors)
- [x] `pnpm test` clean — 155 passed (29 new slack tests, 0 regressions)
- [x] `pnpm depcheck` clean

Part 1 of #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)