### PR TITLE
Slack thread backfill + compose buildChannels factory (part 2 of issue 18)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,9 +9,11 @@
     "dev": "tsx watch src/main.ts"
   },
   "dependencies": {
+    "@agentry/adapter-channel-slack": "workspace:*",
     "@agentry/core": "workspace:*",
     "@agentry/runtime": "workspace:*",
     "@hono/node-server": "^1.19.6",
+    "@slack/web-api": "^7.15.1",
     "hono": "^4.10.4"
   },
   "devDependencies": {

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,11 +1,19 @@
+import {
+  SlackHistoryBackfiller,
+  SlackInboundChannel,
+  SlackOutboundChannel,
+  SlackSessionPolicy,
+} from '@agentry/adapter-channel-slack';
+import type { ChannelKind, OutboundChannel, SessionPolicy } from '@agentry/core';
 import { AgentryConfigSchema, compose, loadSecrets } from '@agentry/runtime';
 import { serve } from '@hono/node-server';
+import { WebClient } from '@slack/web-api';
 import { Hono } from 'hono';
 
-function parsePort(raw: string): number {
+function parsePort(raw: string, label: string): number {
   const port = Number.parseInt(raw, 10);
   if (!Number.isInteger(port) || port < 1 || port > 65535) {
-    throw new Error(`Invalid PORT: ${raw}`);
+    throw new Error(`Invalid ${label}: ${raw}`);
   }
   return port;
 }
@@ -13,11 +21,42 @@ function parsePort(raw: string): number {
 async function main(): Promise<void> {
   const secrets = loadSecrets();
   const config = AgentryConfigSchema.parse({
-    agentWorkdir: process.env['AGENT_WORKDIR'] ?? './seed/agent-workdir',
-    logging: { level: process.env['LOG_LEVEL'] ?? 'info' },
+    agentWorkdir: process.env.AGENT_WORKDIR ?? './seed/agent-workdir',
+    logging: { level: process.env.LOG_LEVEL ?? 'info' },
   });
+  const slackPort = parsePort(process.env.SLACK_PORT ?? '3001', 'SLACK_PORT');
 
-  const handles = await compose({ config, secrets });
+  const handles = await compose({
+    config,
+    secrets,
+    buildChannels: ({ sessionStore }) => {
+      // Single shared WebClient: SlackOutboundChannel posts replies; the
+      // backfiller fetches conversations.replies. Two clients would just
+      // duplicate connection pools.
+      const slackClient = new WebClient(secrets.SLACK_BOT_TOKEN);
+      const policy = new SlackSessionPolicy();
+      const outbound = new SlackOutboundChannel({
+        botToken: secrets.SLACK_BOT_TOKEN,
+        client: slackClient,
+      });
+      const backfiller = new SlackHistoryBackfiller({
+        webClient: slackClient,
+        sessionStore,
+        sessionPolicy: policy,
+      });
+      const inbound = new SlackInboundChannel({
+        botToken: secrets.SLACK_BOT_TOKEN,
+        signingSecret: secrets.SLACK_SIGNING_SECRET,
+        port: slackPort,
+        backfiller,
+      });
+      return {
+        inboundChannels: [inbound],
+        outboundChannels: new Map<ChannelKind, OutboundChannel>([[policy.channelKind, outbound]]),
+        sessionPolicies: new Map<ChannelKind, SessionPolicy>([[policy.channelKind, policy]]),
+      };
+    },
+  });
   const log = handles.logger;
   const ac = new AbortController();
 
@@ -36,7 +75,7 @@ async function main(): Promise<void> {
     }),
   );
 
-  const port = parsePort(process.env['PORT'] ?? '3000');
+  const port = parsePort(process.env.PORT ?? '3000', 'PORT');
   const server = serve({ fetch: app.fetch, port }, (info) => {
     log.info({ port: info.port }, 'agentry server listening');
   });

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -10,5 +10,8 @@
   },
   "include": ["src/**/*"],
   "exclude": ["**/*.test.ts", "**/*.spec.ts", "dist", "node_modules"],
-  "references": [{ "path": "../../packages/runtime" }]
+  "references": [
+    { "path": "../../packages/adapter-channel-slack" },
+    { "path": "../../packages/runtime" }
+  ]
 }

--- a/packages/adapter-channel-slack/src/index.ts
+++ b/packages/adapter-channel-slack/src/index.ts
@@ -5,7 +5,13 @@ export {
   SlackEventMappingError,
 } from './slack-event-mapping.js';
 export {
-  SLACK_REQUIRED_SCOPES_PR1,
+  SLACK_BACKFILLED_METADATA_KEY,
+  SlackHistoryBackfillError,
+  SlackHistoryBackfiller,
+  type SlackHistoryBackfillerOptions,
+} from './slack-history-backfiller.js';
+export {
+  SLACK_REQUIRED_SCOPES,
   SlackInboundChannel,
   type SlackInboundChannelOptions,
 } from './slack-inbound-channel.js';

--- a/packages/adapter-channel-slack/src/index.ts
+++ b/packages/adapter-channel-slack/src/index.ts
@@ -1,5 +1,11 @@
 export { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
 export {
+  SLACK_HISTORY_IDEMPOTENCY_PREFIX,
+  slackHistoryIdempotencyKey,
+  slackNativeRef,
+  slackTsToDate,
+} from './slack-conventions.js';
+export {
   mapAppMentionToIncomingEvent,
   type SlackAppMentionEnvelope,
   SlackEventMappingError,

--- a/packages/adapter-channel-slack/src/slack-conventions.ts
+++ b/packages/adapter-channel-slack/src/slack-conventions.ts
@@ -1,0 +1,25 @@
+import type { ChannelNativeRef } from '@agentry/core';
+
+// Idempotency-key prefix for synthetic events sourced from
+// conversations.replies. Distinct from the live `app_mention` event_id so
+// the use case's de-dup map can't conflate the two.
+export const SLACK_HISTORY_IDEMPOTENCY_PREFIX = 'slack-history:';
+
+export function slackHistoryIdempotencyKey(messageTs: string): string {
+  return `${SLACK_HISTORY_IDEMPOTENCY_PREFIX}${messageTs}`;
+}
+
+// Canonical session key shape per ARCHITECTURE.md §4.3:
+// `slack:${channel_id}:${thread_ts}`. Both the event mapper (for live
+// events) and the backfiller (for synthetic events) build this; keeping
+// the format in one place prevents drift.
+export function slackNativeRef(channel: string, threadTs: string): ChannelNativeRef {
+  return `slack:${channel}:${threadTs}`;
+}
+
+// Slack timestamps are decimal seconds-since-epoch with microsecond
+// fractional part (`"1700000000.000100"`). The mapper, the outbound
+// adapter, and the backfiller all need the Date form.
+export function slackTsToDate(ts: string): Date {
+  return new Date(Number.parseFloat(ts) * 1000);
+}

--- a/packages/adapter-channel-slack/src/slack-event-mapping.ts
+++ b/packages/adapter-channel-slack/src/slack-event-mapping.ts
@@ -1,5 +1,6 @@
 import type { IncomingEvent } from '@agentry/core';
 import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
+import { slackNativeRef, slackTsToDate } from './slack-conventions.js';
 
 // Subset of the Slack `app_mention` envelope we depend on. Bolt's published
 // types are looser; this is the contract we read at runtime, so we pin it
@@ -48,7 +49,7 @@ export function mapAppMentionToIncomingEvent(envelope: SlackAppMentionEnvelope):
   const threadTs = event.thread_ts ?? event.ts;
   return {
     channelKind: SLACK_CHANNEL_KIND,
-    channelNativeRef: `slack:${event.channel}:${threadTs}`,
+    channelNativeRef: slackNativeRef(event.channel, threadTs),
     author: { channelUserId: event.user },
     payload: { text: event.text ?? '' },
     threading: {
@@ -57,7 +58,7 @@ export function mapAppMentionToIncomingEvent(envelope: SlackAppMentionEnvelope):
       thread_ts: threadTs,
       team_id,
     },
-    receivedAt: new Date(Number.parseFloat(event.event_ts) * 1000),
+    receivedAt: slackTsToDate(event.event_ts),
     idempotencyKey: event_id,
   };
 }

--- a/packages/adapter-channel-slack/src/slack-history-backfiller.test.ts
+++ b/packages/adapter-channel-slack/src/slack-history-backfiller.test.ts
@@ -1,0 +1,281 @@
+import {
+  type ChannelKind,
+  type ChannelNativeRef,
+  type DistillationCriteria,
+  type IncomingEvent,
+  type Session,
+  type SessionId,
+  type SessionLifecycleEvent,
+  type SessionPolicy,
+  type SessionStatus,
+  type SessionStore,
+  SYNTHETIC_EVENT_METADATA_KEY,
+  type TenantId,
+  type Turn,
+  type TurnInput,
+} from '@agentry/core';
+import type { WebClient } from '@slack/web-api';
+import { describe, expect, it, vi } from 'vitest';
+import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
+import {
+  SLACK_BACKFILLED_METADATA_KEY,
+  SlackHistoryBackfillError,
+  SlackHistoryBackfiller,
+} from './slack-history-backfiller.js';
+
+interface ConversationsRepliesMessage {
+  readonly user?: string;
+  readonly ts?: string;
+  readonly text?: string;
+  readonly bot_id?: string;
+}
+
+interface ConversationsRepliesResult {
+  readonly ok: boolean;
+  readonly error?: string;
+  readonly messages?: readonly ConversationsRepliesMessage[];
+}
+
+function makeWebClient(
+  replies: (args: {
+    channel: string;
+    ts: string;
+    limit: number;
+  }) => Promise<ConversationsRepliesResult>,
+): WebClient {
+  return {
+    conversations: {
+      replies: vi.fn(replies),
+    },
+  } as unknown as WebClient;
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  const now = new Date('2026-04-01T00:00:00Z');
+  return {
+    id: 'sess-1' as SessionId,
+    tenantId: 'default' as TenantId,
+    channelKind: SLACK_CHANNEL_KIND,
+    channelNativeRef: 'slack:C9:1700000000.000100',
+    startedAt: now,
+    lastActiveAt: now,
+    status: 'active' as SessionStatus,
+    participants: [],
+    metadata: {},
+    distilledThroughSeqNo: 0n,
+    ...overrides,
+  };
+}
+
+interface FakeSessionStore extends SessionStore {
+  readonly findOrCreateMock: ReturnType<typeof vi.fn>;
+  readonly setMetadataMock: ReturnType<typeof vi.fn>;
+}
+
+function makeSessionStore(initial: Session = makeSession()): FakeSessionStore {
+  let current = initial;
+  const findOrCreateMock = vi.fn(async () => current);
+  const setMetadataMock = vi.fn(
+    async (_id: SessionId, patch: Readonly<Record<string, unknown>>) => {
+      current = { ...current, metadata: { ...current.metadata, ...patch } };
+    },
+  );
+  return {
+    findOrCreate: findOrCreateMock as SessionStore['findOrCreate'],
+    setMetadata: setMetadataMock as SessionStore['setMetadata'],
+    recordTurn: vi.fn(async (_id: SessionId, _t: TurnInput): Promise<Turn> => {
+      throw new Error('not used');
+    }),
+    getRecentTurns: vi.fn(async (_id: SessionId, _l: number) => []),
+    updateStatus: vi.fn(async (_id: SessionId, _s: SessionStatus) => {}),
+    listSessionsForDistillation: vi.fn(async (_c: DistillationCriteria) => []),
+    findOrCreateMock,
+    setMetadataMock,
+  };
+}
+
+class StubSlackPolicy implements SessionPolicy {
+  readonly channelKind: ChannelKind = SLACK_CHANNEL_KIND;
+  computeNativeRef(event: IncomingEvent): ChannelNativeRef {
+    return event.channelNativeRef;
+  }
+  idleTimeoutMinutes(): number {
+    return 1440;
+  }
+  shouldEndOn(_event: SessionLifecycleEvent): boolean {
+    return false;
+  }
+}
+
+const liveEvent: IncomingEvent = {
+  channelKind: SLACK_CHANNEL_KIND,
+  channelNativeRef: 'slack:C9:1700000000.000100',
+  author: { channelUserId: 'U1' },
+  payload: { text: '<@UBOT> hi' },
+  threading: {
+    channel: 'C9',
+    thread_ts: '1700000000.000100',
+    message_ts: '1700000123.000200',
+    team_id: 'T1',
+  },
+  receivedAt: new Date(1_700_000_123_000),
+  idempotencyKey: 'EvLive',
+};
+
+describe('SlackHistoryBackfiller', () => {
+  it('returns [] without calling Slack when session is already backfilled', async () => {
+    const store = makeSessionStore(
+      makeSession({ metadata: { [SLACK_BACKFILLED_METADATA_KEY]: true } }),
+    );
+    const repliesFn = vi.fn();
+    const webClient = makeWebClient(repliesFn);
+    const backfiller = new SlackHistoryBackfiller({
+      webClient,
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    const result = await backfiller.backfillIfNeeded(liveEvent, 'default');
+
+    expect(result).toEqual([]);
+    expect(repliesFn).not.toHaveBeenCalled();
+    expect(store.setMetadataMock).not.toHaveBeenCalled();
+  });
+
+  it('maps prior thread messages to synthetic IncomingEvents in chronological order', async () => {
+    const store = makeSessionStore();
+    const repliesFn = vi.fn(async () => ({
+      ok: true,
+      messages: [
+        { user: 'U1', ts: '1700000000.000100', text: 'first' },
+        { user: 'U2', ts: '1700000050.000100', text: 'reply' },
+        { user: 'U1', ts: '1700000123.000200', text: 'live ignored' },
+      ],
+    }));
+    const backfiller = new SlackHistoryBackfiller({
+      webClient: makeWebClient(repliesFn),
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    const result = await backfiller.backfillIfNeeded(liveEvent, 'default');
+
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.idempotencyKey)).toEqual([
+      'slack-history:1700000000.000100',
+      'slack-history:1700000050.000100',
+    ]);
+    const [first] = result;
+    expect(first).toMatchObject({
+      channelKind: SLACK_CHANNEL_KIND,
+      channelNativeRef: 'slack:C9:1700000000.000100',
+      author: { channelUserId: 'U1' },
+      payload: { text: 'first' },
+      metadata: { [SYNTHETIC_EVENT_METADATA_KEY]: true },
+    });
+    expect(first?.threading).toEqual({
+      channel: 'C9',
+      thread_ts: '1700000000.000100',
+      message_ts: '1700000000.000100',
+      team_id: 'T1',
+    });
+  });
+
+  it('excludes bot_id messages so bot replies are not recorded as user turns', async () => {
+    const store = makeSessionStore();
+    const repliesFn = vi.fn(async () => ({
+      ok: true,
+      messages: [
+        { user: 'U1', ts: '1700000000.000100', text: 'human' },
+        { user: 'UBOT', bot_id: 'B123', ts: '1700000010.000100', text: 'bot says' },
+        { user: 'U2', ts: '1700000050.000100', text: 'human 2' },
+      ],
+    }));
+    const backfiller = new SlackHistoryBackfiller({
+      webClient: makeWebClient(repliesFn),
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    const result = await backfiller.backfillIfNeeded(liveEvent, 'default');
+
+    expect(result.map((e) => e.author.channelUserId)).toEqual(['U1', 'U2']);
+  });
+
+  it('marks the session backfilled after a successful first run', async () => {
+    const store = makeSessionStore();
+    const backfiller = new SlackHistoryBackfiller({
+      webClient: makeWebClient(async () => ({ ok: true, messages: [] })),
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    await backfiller.backfillIfNeeded(liveEvent, 'default');
+
+    expect(store.setMetadataMock).toHaveBeenCalledWith('sess-1', {
+      [SLACK_BACKFILLED_METADATA_KEY]: true,
+    });
+  });
+
+  it('throws SlackHistoryBackfillError when conversations.replies returns ok: false', async () => {
+    const store = makeSessionStore();
+    const backfiller = new SlackHistoryBackfiller({
+      webClient: makeWebClient(async () => ({ ok: false, error: 'channel_not_found' })),
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    await expect(backfiller.backfillIfNeeded(liveEvent, 'default')).rejects.toBeInstanceOf(
+      SlackHistoryBackfillError,
+    );
+    expect(store.setMetadataMock).not.toHaveBeenCalled();
+  });
+
+  it('collapses concurrent first-touch calls into a single Slack API request', async () => {
+    const store = makeSessionStore();
+    let resolve!: (value: ConversationsRepliesResult) => void;
+    const inflight = new Promise<ConversationsRepliesResult>((r) => {
+      resolve = r;
+    });
+    const repliesFn = vi.fn(async () => inflight);
+    const backfiller = new SlackHistoryBackfiller({
+      webClient: makeWebClient(repliesFn),
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    const a = backfiller.backfillIfNeeded(liveEvent, 'default');
+    const b = backfiller.backfillIfNeeded(liveEvent, 'default');
+
+    await vi.waitFor(() => {
+      expect(repliesFn).toHaveBeenCalledTimes(1);
+    });
+    resolve({ ok: true, messages: [] });
+    const [resA, resB] = await Promise.all([a, b]);
+    expect(repliesFn).toHaveBeenCalledTimes(1);
+    expect(resA).toEqual([]);
+    expect(resB).toEqual([]);
+  });
+
+  it('does not poison the lock when a backfill throws — next call retries', async () => {
+    const store = makeSessionStore();
+    let calls = 0;
+    const repliesFn = vi.fn(async () => {
+      calls += 1;
+      if (calls === 1) return { ok: false, error: 'rate_limited' };
+      return { ok: true, messages: [] };
+    });
+    const backfiller = new SlackHistoryBackfiller({
+      webClient: makeWebClient(repliesFn),
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    await expect(backfiller.backfillIfNeeded(liveEvent, 'default')).rejects.toBeInstanceOf(
+      SlackHistoryBackfillError,
+    );
+    const second = await backfiller.backfillIfNeeded(liveEvent, 'default');
+    expect(second).toEqual([]);
+    expect(repliesFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/adapter-channel-slack/src/slack-history-backfiller.ts
+++ b/packages/adapter-channel-slack/src/slack-history-backfiller.ts
@@ -9,6 +9,7 @@ import {
 } from '@agentry/core';
 import type { WebClient } from '@slack/web-api';
 import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
+import { slackHistoryIdempotencyKey, slackNativeRef, slackTsToDate } from './slack-conventions.js';
 
 // Slack-specific session metadata uses flat-prefixed keys (e.g.
 // `slackBackfilled`) until SessionStore gains atomic deeper-merge.
@@ -83,9 +84,10 @@ export class SlackHistoryBackfiller {
     const result = await this.opts.webClient.conversations.replies({
       channel: threading.channel,
       ts: threading.thread_ts,
-      // Slack max page size; treats deep threads as truncated rather than
-      // paginating. The 3-second ack budget makes multi-page fetch risky
-      // in PR2 — followup work if real threads start hitting the cap.
+      // Slack max page size; deep threads are truncated rather than
+      // paginated. Slack's 3-second ack budget makes multi-page fetch
+      // risky on the inbound hot path; revisit if real threads exceed the
+      // cap.
       limit: 1000,
     });
     if (!result.ok || !result.messages) {
@@ -150,7 +152,7 @@ function buildSyntheticEvent(msg: BackfillMessage, threading: SlackThreadingShap
   }
   return {
     channelKind: SLACK_CHANNEL_KIND,
-    channelNativeRef: `slack:${threading.channel}:${threading.thread_ts}`,
+    channelNativeRef: slackNativeRef(threading.channel, threading.thread_ts),
     author: { channelUserId: user },
     payload: { text: msg.text ?? '' },
     threading: {
@@ -159,8 +161,8 @@ function buildSyntheticEvent(msg: BackfillMessage, threading: SlackThreadingShap
       message_ts: ts,
       team_id: threading.team_id,
     },
-    receivedAt: new Date(Number.parseFloat(ts) * 1000),
-    idempotencyKey: `slack-history:${ts}`,
+    receivedAt: slackTsToDate(ts),
+    idempotencyKey: slackHistoryIdempotencyKey(ts),
     metadata: { [SYNTHETIC_EVENT_METADATA_KEY]: true },
   };
 }

--- a/packages/adapter-channel-slack/src/slack-history-backfiller.ts
+++ b/packages/adapter-channel-slack/src/slack-history-backfiller.ts
@@ -84,10 +84,13 @@ export class SlackHistoryBackfiller {
     const result = await this.opts.webClient.conversations.replies({
       channel: threading.channel,
       ts: threading.thread_ts,
-      // Slack max page size; deep threads are truncated rather than
-      // paginated. Slack's 3-second ack budget makes multi-page fetch
-      // risky on the inbound hot path; revisit if real threads exceed the
-      // cap.
+      // Slack returns replies oldest-first, one page at a time. With
+      // limit: 1000 (Slack's max), a thread of >1000 messages truncates
+      // the MOST RECENT tail — i.e. the part the agent most needs for
+      // context. Slack's 3-second ack budget rules out multi-page fetch
+      // on the inbound hot path. Followup work: invert pagination (latest
+      // first) and/or move backfill off the ack path if real threads
+      // start hitting the cap.
       limit: 1000,
     });
     if (!result.ok || !result.messages) {

--- a/packages/adapter-channel-slack/src/slack-history-backfiller.ts
+++ b/packages/adapter-channel-slack/src/slack-history-backfiller.ts
@@ -1,0 +1,166 @@
+import {
+  type ChannelNativeRef,
+  type IncomingEvent,
+  type SessionPolicy,
+  type SessionStore,
+  SYNTHETIC_EVENT_METADATA_KEY,
+  type TenantId,
+  type ThreadingMetadata,
+} from '@agentry/core';
+import type { WebClient } from '@slack/web-api';
+import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
+
+// Slack-specific session metadata uses flat-prefixed keys (e.g.
+// `slackBackfilled`) until SessionStore gains atomic deeper-merge.
+// PgvectorSessionStore.setMetadata is a shallow JSONB merge, so a nested
+// `slack: { backfilled: true }` shape would clobber sibling slack.* keys
+// on every write.
+export const SLACK_BACKFILLED_METADATA_KEY = 'slackBackfilled';
+
+interface SlackThreadingShape {
+  readonly channel: string;
+  readonly thread_ts: string;
+  readonly message_ts: string;
+  readonly team_id: string;
+}
+
+export interface SlackHistoryBackfillerOptions {
+  readonly webClient: WebClient;
+  readonly sessionStore: SessionStore;
+  readonly sessionPolicy: SessionPolicy;
+}
+
+export class SlackHistoryBackfillError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SlackHistoryBackfillError';
+  }
+}
+
+export class SlackHistoryBackfiller {
+  private readonly opts: SlackHistoryBackfillerOptions;
+  // In-memory promise lock keyed by nativeRef collapses concurrent
+  // first-touch events for the same session into one Slack API call. The
+  // persistent `slackBackfilled` metadata flag covers the cross-restart
+  // case; this map covers the single-process race window. Multi-instance
+  // deployments still have a narrow same-session-different-process race
+  // (accepted for the MVP).
+  private readonly inFlight = new Map<ChannelNativeRef, Promise<readonly IncomingEvent[]>>();
+
+  constructor(opts: SlackHistoryBackfillerOptions) {
+    this.opts = opts;
+  }
+
+  async backfillIfNeeded(
+    liveEvent: IncomingEvent,
+    tenant: TenantId,
+  ): Promise<readonly IncomingEvent[]> {
+    const ref = this.opts.sessionPolicy.computeNativeRef(liveEvent);
+    const existing = this.inFlight.get(ref);
+    if (existing) return existing;
+    const promise = this.runBackfill(liveEvent, tenant, ref);
+    this.inFlight.set(ref, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inFlight.delete(ref);
+    }
+  }
+
+  private async runBackfill(
+    liveEvent: IncomingEvent,
+    tenant: TenantId,
+    ref: ChannelNativeRef,
+  ): Promise<readonly IncomingEvent[]> {
+    const session = await this.opts.sessionStore.findOrCreate(
+      this.opts.sessionPolicy.channelKind,
+      ref,
+      tenant,
+    );
+    if (session.metadata[SLACK_BACKFILLED_METADATA_KEY] === true) return [];
+
+    const threading = readThreading(liveEvent.threading);
+    const result = await this.opts.webClient.conversations.replies({
+      channel: threading.channel,
+      ts: threading.thread_ts,
+      // Slack max page size; treats deep threads as truncated rather than
+      // paginating. The 3-second ack budget makes multi-page fetch risky
+      // in PR2 — followup work if real threads start hitting the cap.
+      limit: 1000,
+    });
+    if (!result.ok || !result.messages) {
+      throw new SlackHistoryBackfillError(
+        `conversations.replies failed: ${result.error ?? 'no messages'}`,
+      );
+    }
+
+    const synthetics: IncomingEvent[] = [];
+    for (const msg of result.messages) {
+      // bot_id filters bot's OWN past replies; msg.user is set on bot
+      // messages too, so a `!msg.user` check would let them through. The
+      // use case records all synthetic events as authorRole: 'user', so
+      // recording bot replies as "user said" would corrupt agent context.
+      // Bot history is dropped entirely until SessionStore gains a
+      // direct write path that can record agent turns.
+      if (msg.bot_id !== undefined) continue;
+      if (!msg.user || !msg.ts) continue;
+      if (msg.ts === threading.message_ts) continue;
+      synthetics.push(buildSyntheticEvent(msg, threading));
+    }
+
+    await this.opts.sessionStore.setMetadata(session.id, {
+      [SLACK_BACKFILLED_METADATA_KEY]: true,
+    });
+    return synthetics;
+  }
+}
+
+interface BackfillMessage {
+  readonly user?: string;
+  readonly ts?: string;
+  readonly text?: string;
+  readonly bot_id?: string;
+}
+
+function readThreading(threading: ThreadingMetadata): SlackThreadingShape {
+  const channel = threading.channel;
+  const threadTs = threading.thread_ts;
+  const messageTs = threading.message_ts;
+  const teamId = threading.team_id;
+  if (
+    typeof channel !== 'string' ||
+    typeof threadTs !== 'string' ||
+    typeof messageTs !== 'string' ||
+    typeof teamId !== 'string'
+  ) {
+    throw new SlackHistoryBackfillError(
+      `live event threading missing slack keys: ${JSON.stringify(threading)}`,
+    );
+  }
+  return { channel, thread_ts: threadTs, message_ts: messageTs, team_id: teamId };
+}
+
+function buildSyntheticEvent(msg: BackfillMessage, threading: SlackThreadingShape): IncomingEvent {
+  const user = msg.user;
+  const ts = msg.ts;
+  if (!user || !ts) {
+    throw new SlackHistoryBackfillError(
+      `buildSyntheticEvent called with incomplete message: ${JSON.stringify(msg)}`,
+    );
+  }
+  return {
+    channelKind: SLACK_CHANNEL_KIND,
+    channelNativeRef: `slack:${threading.channel}:${threading.thread_ts}`,
+    author: { channelUserId: user },
+    payload: { text: msg.text ?? '' },
+    threading: {
+      channel: threading.channel,
+      thread_ts: threading.thread_ts,
+      message_ts: ts,
+      team_id: threading.team_id,
+    },
+    receivedAt: new Date(Number.parseFloat(ts) * 1000),
+    idempotencyKey: `slack-history:${ts}`,
+    metadata: { [SYNTHETIC_EVENT_METADATA_KEY]: true },
+  };
+}

--- a/packages/adapter-channel-slack/src/slack-inbound-channel.test.ts
+++ b/packages/adapter-channel-slack/src/slack-inbound-channel.test.ts
@@ -1,6 +1,7 @@
-import type { IncomingEvent, Logger } from '@agentry/core';
+import type { IncomingEvent, Logger, TenantId } from '@agentry/core';
 import type { App } from '@slack/bolt';
 import { describe, expect, it, vi } from 'vitest';
+import type { SlackHistoryBackfiller } from './slack-history-backfiller.js';
 import { SlackInboundChannel } from './slack-inbound-channel.js';
 
 // dep-cruiser forbids adapter-* → @agentry/testing imports (the testing
@@ -168,6 +169,143 @@ describe('SlackInboundChannel', () => {
       channelNativeRef: 'slack:C9:1700000000.000100',
       idempotencyKey: 'EvX',
     });
+
+    ac.abort();
+    await startPromise;
+  });
+
+  it('forwards synthetic events from the backfiller before the live event', async () => {
+    const { app, captured } = fakeApp();
+    const seen: IncomingEvent[] = [];
+    const synthetic: IncomingEvent = {
+      channelKind: 'slack',
+      channelNativeRef: 'slack:C9:1700000000.000100',
+      author: { channelUserId: 'U9' },
+      payload: { text: 'historical' },
+      threading: {
+        channel: 'C9',
+        thread_ts: '1700000000.000100',
+        message_ts: '1700000050.000100',
+        team_id: 'T1',
+      },
+      receivedAt: new Date(1_700_000_050_000),
+      idempotencyKey: 'slack-history:1700000050.000100',
+      metadata: { synthetic: true },
+    };
+    const backfiller = {
+      backfillIfNeeded: vi.fn(async () => [synthetic]),
+    } as unknown as SlackHistoryBackfiller;
+    const ch = new SlackInboundChannel({
+      ...baseOpts,
+      app,
+      backfiller,
+      fetch: fakeFetchOk(['app_mentions:read', 'chat:write', 'channels:history', 'groups:history']),
+    });
+    const ac = new AbortController();
+    const startPromise = ch.start(async (e) => {
+      seen.push(e);
+    }, ac.signal);
+    const handler = await waitForHandler(captured);
+
+    await handler({
+      event: {
+        type: 'app_mention',
+        user: 'U1',
+        text: 'hi',
+        ts: '1700000123.000200',
+        thread_ts: '1700000000.000100',
+        channel: 'C9',
+        event_ts: '1700000123.000200',
+      },
+      body: { event_id: 'EvX', team_id: 'T1' },
+      logger: silentLogger,
+    });
+
+    expect(seen.map((e) => e.idempotencyKey)).toEqual(['slack-history:1700000050.000100', 'EvX']);
+
+    ac.abort();
+    await startPromise;
+  });
+
+  it('still forwards the live event when the backfiller throws (warn logged)', async () => {
+    const { app, captured } = fakeApp();
+    const seen: IncomingEvent[] = [];
+    const warnLog = vi.fn();
+    const logger: Logger = { ...silentLogger, warn: warnLog };
+    const backfiller = {
+      backfillIfNeeded: vi.fn(async () => {
+        throw new Error('rate_limited');
+      }),
+    } as unknown as SlackHistoryBackfiller;
+    const ch = new SlackInboundChannel({
+      ...baseOpts,
+      app,
+      backfiller,
+      logger,
+      fetch: fakeFetchOk(['app_mentions:read', 'chat:write', 'channels:history', 'groups:history']),
+    });
+    const ac = new AbortController();
+    const startPromise = ch.start(async (e) => {
+      seen.push(e);
+    }, ac.signal);
+    const handler = await waitForHandler(captured);
+
+    await handler({
+      event: {
+        type: 'app_mention',
+        user: 'U1',
+        text: 'hi',
+        ts: '1700000123.000200',
+        thread_ts: '1700000000.000100',
+        channel: 'C9',
+        event_ts: '1700000123.000200',
+      },
+      body: { event_id: 'EvX', team_id: 'T1' },
+      logger,
+    });
+
+    expect(seen.map((e) => e.idempotencyKey)).toEqual(['EvX']);
+    expect(warnLog).toHaveBeenCalledOnce();
+
+    ac.abort();
+    await startPromise;
+  });
+
+  it('passes the resolveTenant result to the backfiller', async () => {
+    const { app, captured } = fakeApp();
+    const backfillIfNeeded = vi.fn(async () => []);
+    const backfiller = { backfillIfNeeded } as unknown as SlackHistoryBackfiller;
+    const resolveTenant = vi.fn((_e: IncomingEvent): TenantId => 'tenant-A');
+    const ch = new SlackInboundChannel({
+      ...baseOpts,
+      app,
+      backfiller,
+      resolveTenant,
+      fetch: fakeFetchOk(['app_mentions:read', 'chat:write', 'channels:history', 'groups:history']),
+    });
+    const ac = new AbortController();
+    const startPromise = ch.start(async () => {}, ac.signal);
+    const handler = await waitForHandler(captured);
+
+    await handler({
+      event: {
+        type: 'app_mention',
+        user: 'U1',
+        text: 'hi',
+        ts: '1700000123.000200',
+        thread_ts: '1700000000.000100',
+        channel: 'C9',
+        event_ts: '1700000123.000200',
+      },
+      body: { event_id: 'EvX', team_id: 'T1' },
+      logger: silentLogger,
+    });
+
+    expect(resolveTenant).toHaveBeenCalledOnce();
+    expect(backfillIfNeeded).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: 'EvX' }),
+      'tenant-A',
+    );
 
     ac.abort();
     await startPromise;

--- a/packages/adapter-channel-slack/src/slack-inbound-channel.test.ts
+++ b/packages/adapter-channel-slack/src/slack-inbound-channel.test.ts
@@ -1,4 +1,9 @@
-import type { IncomingEvent, Logger, TenantId } from '@agentry/core';
+import {
+  type IncomingEvent,
+  type Logger,
+  SYNTHETIC_EVENT_METADATA_KEY,
+  type TenantId,
+} from '@agentry/core';
 import type { App } from '@slack/bolt';
 import { describe, expect, it, vi } from 'vitest';
 import type { SlackHistoryBackfiller } from './slack-history-backfiller.js';
@@ -190,7 +195,7 @@ describe('SlackInboundChannel', () => {
       },
       receivedAt: new Date(1_700_000_050_000),
       idempotencyKey: 'slack-history:1700000050.000100',
-      metadata: { synthetic: true },
+      metadata: { [SYNTHETIC_EVENT_METADATA_KEY]: true },
     };
     const backfiller = {
       backfillIfNeeded: vi.fn(async () => [synthetic]),

--- a/packages/adapter-channel-slack/src/slack-inbound-channel.ts
+++ b/packages/adapter-channel-slack/src/slack-inbound-channel.ts
@@ -1,15 +1,23 @@
-import type { ChannelKind, InboundChannel, IncomingEvent, Logger } from '@agentry/core';
+import type { ChannelKind, InboundChannel, IncomingEvent, Logger, TenantId } from '@agentry/core';
 import { App } from '@slack/bolt';
 import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
 import {
   mapAppMentionToIncomingEvent,
   type SlackAppMentionEnvelope,
 } from './slack-event-mapping.js';
+import type { SlackHistoryBackfiller } from './slack-history-backfiller.js';
 import { verifySlackScopes } from './slack-scope-verifier.js';
 
-// Required for receiving channel mentions and replying (excludes thread
-// backfill scopes — those belong to PR2 when the backfill path lands).
-export const SLACK_REQUIRED_SCOPES_PR1: readonly string[] = ['app_mentions:read', 'chat:write'];
+// Channel mention + thread backfill scopes. Reading prior thread messages
+// requires `*:history` per channel type the bot is invited to.
+export const SLACK_REQUIRED_SCOPES: readonly string[] = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:history',
+];
+
+const DEFAULT_TENANT: TenantId = 'default';
 
 export interface SlackInboundChannelOptions {
   readonly botToken: string;
@@ -21,6 +29,11 @@ export interface SlackInboundChannelOptions {
   readonly app?: App;
   readonly fetch?: typeof globalThis.fetch;
   readonly requiredScopes?: readonly string[];
+  // Optional thread-history backfill: when set, the channel calls
+  // backfillIfNeeded on first contact and forwards synthetic events
+  // (history-only) to the handler before the live event.
+  readonly backfiller?: SlackHistoryBackfiller;
+  readonly resolveTenant?: (event: IncomingEvent) => TenantId;
 }
 
 export class SlackInboundChannel implements InboundChannel {
@@ -47,7 +60,7 @@ export class SlackInboundChannel implements InboundChannel {
     this.started = true;
     if (signal.aborted) return;
 
-    const required = this.opts.requiredScopes ?? SLACK_REQUIRED_SCOPES_PR1;
+    const required = this.opts.requiredScopes ?? SLACK_REQUIRED_SCOPES;
     await verifySlackScopes(this.opts.botToken, required, this.opts.fetch);
 
     const app =
@@ -58,6 +71,7 @@ export class SlackInboundChannel implements InboundChannel {
       });
 
     app.event('app_mention', async ({ event, body, logger }) => {
+      const log = this.opts.logger ?? logger;
       try {
         const b = body as { event_id?: unknown; team_id?: unknown };
         const envelope: SlackAppMentionEnvelope = {
@@ -65,14 +79,28 @@ export class SlackInboundChannel implements InboundChannel {
           event_id: typeof b.event_id === 'string' ? b.event_id : '',
           team_id: typeof b.team_id === 'string' ? b.team_id : '',
         };
-        const incoming = mapAppMentionToIncomingEvent(envelope);
-        await handler(incoming);
+        const live = mapAppMentionToIncomingEvent(envelope);
+        const tenant = (this.opts.resolveTenant ?? (() => DEFAULT_TENANT))(live);
+
+        // Inner try/catch around backfill ONLY: a backfill failure must not
+        // drop the live event. Without this, a transient Slack API error
+        // (rate limit, network blip) would silently drop the user's mention.
+        let synthetics: readonly IncomingEvent[] = [];
+        if (this.opts.backfiller) {
+          try {
+            synthetics = await this.opts.backfiller.backfillIfNeeded(live, tenant);
+          } catch (err) {
+            log.warn({ err }, 'slack history backfill failed; proceeding without synthetics');
+          }
+        }
+
+        for (const synth of synthetics) await handler(synth);
+        await handler(live);
       } catch (err) {
         // Log and swallow: failing here would cause Bolt to leave the request
         // un-acked, prompting Slack to redeliver (idempotency handles the
         // dup but we'd burn time on every redelivery). Errors after enqueue
         // are the JobRunner's concern.
-        const log = this.opts.logger ?? logger;
         log.error({ err }, 'slack app_mention handling failed');
       }
     });

--- a/packages/adapter-channel-slack/src/slack-outbound-channel.ts
+++ b/packages/adapter-channel-slack/src/slack-outbound-channel.ts
@@ -7,11 +7,15 @@ import type {
 } from '@agentry/core';
 import { WebClient } from '@slack/web-api';
 import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
+import { slackTsToDate } from './slack-conventions.js';
 
 export interface SlackOutboundChannelOptions {
   readonly botToken: string;
-  // Test seam: inject a pre-built WebClient (used by unit tests with mocked
-  // chat.postMessage). When omitted, the constructor builds one from token.
+  // Shared WebClient seam. Production: the composition root passes one
+  // client to both the outbound channel (for chat.postMessage) and the
+  // history backfiller (for conversations.replies) so both share a
+  // connection pool. Tests: inject a mock with the methods the test
+  // exercises.
   readonly client?: WebClient;
 }
 
@@ -58,7 +62,7 @@ export class SlackOutboundChannel implements OutboundChannel {
 
     return {
       messageId: result.ts,
-      postedAt: new Date(Number.parseFloat(result.ts) * 1000),
+      postedAt: slackTsToDate(result.ts),
       metadata: { channel, thread_ts: threadTs },
     };
   }

--- a/packages/runtime/src/compose.test.ts
+++ b/packages/runtime/src/compose.test.ts
@@ -163,7 +163,7 @@ describe('compose', () => {
     await handles.shutdown();
   });
 
-  it('invokes buildChannels with sessionStore + logger after storage init', async () => {
+  it('invokes buildChannels with the composed sessionStore after storage init', async () => {
     const { asPool } = makeStubPool();
     const buildChannels = vi.fn(() => ({}));
 
@@ -177,7 +177,6 @@ describe('compose', () => {
     expect(buildChannels).toHaveBeenCalledTimes(1);
     const deps = buildChannels.mock.calls[0]?.[0];
     expect(deps?.sessionStore).toBe(handles.sessionStore);
-    expect(deps?.logger).toBe(handles.logger);
     await handles.shutdown();
   });
 

--- a/packages/runtime/src/compose.test.ts
+++ b/packages/runtime/src/compose.test.ts
@@ -162,4 +162,77 @@ describe('compose', () => {
     expect(handles.inboundChannels).toBe(inbound);
     await handles.shutdown();
   });
+
+  it('invokes buildChannels with sessionStore + logger after storage init', async () => {
+    const { asPool } = makeStubPool();
+    const buildChannels = vi.fn(() => ({}));
+
+    const handles = await compose({
+      config,
+      secrets,
+      poolFactory: () => asPool,
+      buildChannels,
+    });
+
+    expect(buildChannels).toHaveBeenCalledTimes(1);
+    const deps = buildChannels.mock.calls[0]?.[0];
+    expect(deps?.sessionStore).toBe(handles.sessionStore);
+    expect(deps?.logger).toBe(handles.logger);
+    await handles.shutdown();
+  });
+
+  it('lets buildChannels result win over static inbound/outbound/policy options', async () => {
+    const { asPool } = makeStubPool();
+    const staticInbound: InboundChannel[] = [{ kind: 'static', async start() {} }];
+    const factoryInbound: InboundChannel[] = [{ kind: 'factory', async start() {} }];
+    const factoryPolicy = new StaticSessionPolicy({ channelKind: 'factory' });
+    const factoryOutbound = new RecordingOutboundChannel('factory');
+
+    const handles = await compose({
+      config,
+      secrets,
+      poolFactory: () => asPool,
+      inboundChannels: staticInbound,
+      buildChannels: () => ({
+        inboundChannels: factoryInbound,
+        outboundChannels: new Map<ChannelKind, OutboundChannel>([['factory', factoryOutbound]]),
+        sessionPolicies: new Map<ChannelKind, SessionPolicy>([['factory', factoryPolicy]]),
+      }),
+    });
+
+    expect(handles.inboundChannels).toBe(factoryInbound);
+    await handles.shutdown();
+  });
+
+  it('awaits async buildChannels factories', async () => {
+    const { asPool } = makeStubPool();
+    const factoryInbound: InboundChannel[] = [{ kind: 'async', async start() {} }];
+
+    const handles = await compose({
+      config,
+      secrets,
+      poolFactory: () => asPool,
+      buildChannels: async () => {
+        await Promise.resolve();
+        return { inboundChannels: factoryInbound };
+      },
+    });
+
+    expect(handles.inboundChannels).toBe(factoryInbound);
+    await handles.shutdown();
+  });
+
+  it('falls back to defaults when buildChannels returns an empty result', async () => {
+    const { asPool } = makeStubPool();
+
+    const handles = await compose({
+      config,
+      secrets,
+      poolFactory: () => asPool,
+      buildChannels: () => ({}),
+    });
+
+    expect(handles.inboundChannels).toEqual([]);
+    await handles.shutdown();
+  });
 });

--- a/packages/runtime/src/compose.ts
+++ b/packages/runtime/src/compose.ts
@@ -23,6 +23,17 @@ import { Pool } from 'pg';
 import type { AgentryConfig } from './config/agentry-config.js';
 import type { Secrets } from './config/secrets.js';
 
+export interface BuildChannelsDeps {
+  readonly sessionStore: SessionStore;
+  readonly logger: Logger;
+}
+
+export interface BuildChannelsResult {
+  readonly inboundChannels?: readonly InboundChannel[];
+  readonly outboundChannels?: ReadonlyMap<ChannelKind, OutboundChannel>;
+  readonly sessionPolicies?: ReadonlyMap<ChannelKind, SessionPolicy>;
+}
+
 export interface ComposeArgs {
   readonly config: AgentryConfig;
   readonly secrets: Secrets;
@@ -32,11 +43,18 @@ export interface ComposeArgs {
   readonly spawn?: SpawnFn;
   readonly loggerDestination?: NodeJS.WritableStream;
   // Channel registry. Empty by default — server boots and serves /health,
-  // but `handleIncoming` will throw on dispatch until channels are wired
-  // (i.e. until #18 ships the Slack adapter).
+  // but `handleIncoming` will throw on dispatch until channels are wired.
   readonly inboundChannels?: readonly InboundChannel[];
   readonly outboundChannels?: ReadonlyMap<ChannelKind, OutboundChannel>;
   readonly sessionPolicies?: ReadonlyMap<ChannelKind, SessionPolicy>;
+  // Channel adapters that need access to compose-built infrastructure
+  // (e.g. SlackHistoryBackfiller wants the SessionStore) provide a factory
+  // here. When supplied, its result wins over the static channel options
+  // above; the factory is invoked AFTER storage init and BEFORE
+  // makeHandleIncomingMessage. May be sync or async.
+  readonly buildChannels?: (
+    deps: BuildChannelsDeps,
+  ) => BuildChannelsResult | Promise<BuildChannelsResult>;
   // Single-tenant deployments default to 'default'. Multi-tenant deployments
   // MUST override with a real per-event tenant resolver.
   readonly resolveTenant?: (event: IncomingEvent) => TenantId;
@@ -87,13 +105,18 @@ export async function compose(args: ComposeArgs): Promise<RuntimeHandles> {
     },
   });
 
+  const built = args.buildChannels ? await args.buildChannels({ sessionStore, logger }) : undefined;
+  const inboundChannels = built?.inboundChannels ?? args.inboundChannels ?? [];
+  const outboundChannels = built?.outboundChannels ?? args.outboundChannels ?? new Map();
+  const sessionPolicies = built?.sessionPolicies ?? args.sessionPolicies ?? new Map();
+
   const handleIncoming = makeHandleIncomingMessage({
     sessionStore,
     knowledgeStore,
     agentRunner,
     jobRunner,
-    sessionPolicies: args.sessionPolicies ?? new Map(),
-    outboundChannels: args.outboundChannels ?? new Map(),
+    sessionPolicies,
+    outboundChannels,
     resolveTenant: args.resolveTenant ?? (() => DEFAULT_TENANT),
     agentWorkdir: config.agentWorkdir,
     logger,
@@ -107,7 +130,7 @@ export async function compose(args: ComposeArgs): Promise<RuntimeHandles> {
     jobRunner,
     embeddingProvider,
     handleIncoming,
-    inboundChannels: args.inboundChannels ?? [],
+    inboundChannels,
     shutdown: async () => {
       // jobRunner.drain() must complete before pool.end() — running jobs may
       // still need the pool to record turns or query knowledge.

--- a/packages/runtime/src/compose.ts
+++ b/packages/runtime/src/compose.ts
@@ -25,7 +25,6 @@ import type { Secrets } from './config/secrets.js';
 
 export interface BuildChannelsDeps {
   readonly sessionStore: SessionStore;
-  readonly logger: Logger;
 }
 
 export interface BuildChannelsResult {
@@ -105,7 +104,7 @@ export async function compose(args: ComposeArgs): Promise<RuntimeHandles> {
     },
   });
 
-  const built = args.buildChannels ? await args.buildChannels({ sessionStore, logger }) : undefined;
+  const built = args.buildChannels ? await args.buildChannels({ sessionStore }) : undefined;
   const inboundChannels = built?.inboundChannels ?? args.inboundChannels ?? [];
   const outboundChannels = built?.outboundChannels ?? args.outboundChannels ?? new Map();
   const sessionPolicies = built?.sessionPolicies ?? args.sessionPolicies ?? new Map();

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,5 +1,10 @@
 export const RUNTIME_VERSION = '0.0.0' as const;
 
-export type { ComposeArgs, RuntimeHandles } from './compose.js';
+export type {
+  BuildChannelsDeps,
+  BuildChannelsResult,
+  ComposeArgs,
+  RuntimeHandles,
+} from './compose.js';
 export { compose } from './compose.js';
 export * from './config/index.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@agentry/adapter-channel-slack':
+        specifier: workspace:*
+        version: link:../../packages/adapter-channel-slack
       '@agentry/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -60,6 +63,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.19.6
         version: 1.19.14(hono@4.12.15)
+      '@slack/web-api':
+        specifier: ^7.15.1
+        version: 7.15.1
       hono:
         specifier: ^4.10.4
         version: 4.12.15


### PR DESCRIPTION
## Summary

Part 2 (final) of issue 18.

- Adds `SlackHistoryBackfiller` that maps prior thread messages to synthetic `IncomingEvent`s on first contact. Bot replies are filtered via `msg.bot_id` (the use case records all synthetic events as `authorRole: 'user'`, so admitting bot history would corrupt agent context). Concurrent first-touch events for the same session collapse into one Slack API call via an in-memory promise lock keyed by `channelNativeRef`; a persistent `slackBackfilled` metadata flag covers cross-restart cases.
- Wires the backfiller into `SlackInboundChannel`. Backfill is wrapped in an inner try/catch so a transient Slack API error logs warn and proceeds with the live event rather than dropping it.
- Adds `compose()`'s `buildChannels` factory: a sync-or-async hook that receives the composed `sessionStore` and returns the channel registry. Lets adapters that depend on compose-built infrastructure participate in the composition root.
- Wires Slack in `apps/server/main.ts` via the new factory: a single `WebClient` is shared between `SlackOutboundChannel` and `SlackHistoryBackfiller` so they reuse the connection pool. Adds `SLACK_PORT` (default 3001).
- `/simplify` cleanup pass extracts shared Slack conventions (`slackNativeRef`, `slackTsToDate`, `slackHistoryIdempotencyKey`) into `slack-conventions.ts`, fixes a stringly-typed `synthetic: true` literal in tests (now uses `SYNTHETIC_EVENT_METADATA_KEY`), and trims `BuildChannelsDeps` to the one field a consumer actually needs.

## Required scopes

`SLACK_REQUIRED_SCOPES_PR1` is renamed to `SLACK_REQUIRED_SCOPES` and now includes:
- `app_mentions:read`
- `chat:write`
- `channels:history` (new)
- `groups:history` (new)

The latter two are required by `conversations.replies`. Existing deployments must reinstall the bot to grant the new scopes.

## Known limitations (tracked as followups, NOT blockers for this PR)

- Backfill blocks the 3-second Slack ack budget — see issue 63
- Per-message `findOrCreate` runs even on already-backfilled threads — see issue 64
- `conversations.replies` returns oldest-first; threads of >1000 messages truncate the most recent tail (the part the agent most needs). Inline comment captures the followup direction.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors; 6 infos all pre-existing on unchanged files)
- [x] `pnpm test` clean (169 passed, 26 skipped)
- [x] `pnpm depcheck` clean (107 modules, 219 dependencies cruised)
- [x] New tests cover: already-backfilled session short-circuit, chronological mapping, bot-message filter via `bot_id`, metadata write after success, `conversations.replies` error → typed error, in-memory lock collapses concurrent calls, lock recovers from a thrown call, inbound forwards synthetics-then-live, inbound proceeds when backfill throws, `resolveTenant` plumbs through to backfiller, compose factory wins over static options, async factory awaited, empty factory result falls back to defaults
- [ ] Manual smoke: bot installed in a test workspace, mention triggers a reply, both turns land in `sessions`/`turns`, second mention in same thread does NOT re-fetch history

Closes #18
