### PR TITLE
feat(slack): MCP server + agentry-slack verify-scopes (PR1 of #26)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -252,6 +252,11 @@ interface SessionPolicy {
   computeNativeRef(event: IncomingEvent): ChannelNativeRef;
   idleTimeoutMinutes(): number;
   shouldEndOn(e: SessionLifecycleEvent): boolean;
+  // Optional. Returned key/value pairs are prepended to the agent prompt
+  // under `CHANNEL_CONTEXT_HEADER` so the agent can resolve "this channel"
+  // references when calling adapter MCP tools (see §11). Empty / missing →
+  // no header is added.
+  toAgentContext?(event: IncomingEvent): Readonly<Record<string, string>>;
 }
 
 // Open kind. Common values: 'idle_timeout' (JobRunner-fired after

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -685,8 +685,13 @@ choose per tool which mechanism fits.
 ### 11.1 MCP servers (recommended for structured, high-frequency tools)
 
 Each adapter MAY ship a stdio MCP server in `<adapter-package>/mcp/`. The
-composition root collects enabled servers and writes (or merges into)
-`seed/agent-workdir/.mcp.json` at startup. Claude CLI auto-loads them.
+composition root collects enabled servers from the channel-build factory and
+hands them to `ClaudeCliAgentRunner`, which serializes the list into a
+process-private tempfile (`os.tmpdir()`, mode 0600) and points Claude CLI at
+it via `--mcp-config <path>` on every spawn. Claude CLI also auto-loads any
+`.mcp.json` it discovers in `agentWorkdir`, so user-supplied servers in a
+fork's seed continue to work alongside the framework set (we deliberately do
+NOT pass `--strict-mcp-config`).
 
 Use MCP for:
 - High-frequency calls during a conversation (channel history fetch, message search)
@@ -725,16 +730,21 @@ consumer and start there. The Slack adapter ships MCP for `slack_*` tools
 ### 11.4 Composition wiring
 
 ```ts
-const slackChannel = new SlackInboundChannel(config.slack);
-const slackMcp     = new SlackMcpServer(config.slack);  // opt-in
-const slackCli     = registerSlackCli(config.slack);    // installed as bin/
-
-const mcpServers = [slackMcp /*, ...*/].filter(s => s.enabled);
-mergeAgentWorkdirMcpJson(seedDir, mcpServers);
+// In compose's buildChannels factory:
+return {
+  inboundChannels: [slackInbound],
+  outboundChannels,
+  sessionPolicies,
+  mcpServers: [slackMcpServerConfig({ botToken })],
+};
+// compose.ts then constructs ClaudeCliAgentRunner({ mcpServers }), which
+// writes a tempfile and adds `--mcp-config <path>` to every Claude CLI spawn.
 ```
 
-The agent-workdir's existing `.mcp.json` (user customizations) is preserved during
-the merge — framework-managed entries are namespaced.
+Framework-managed entries are namespaced under `agentry-*` (e.g.
+`agentry-slack`). User-supplied entries in `agentWorkdir/.mcp.json` keep their
+own names and are loaded by Claude CLI alongside the framework set; the
+runtime never reads or rewrites that file.
 
 ---
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -3,6 +3,7 @@ import {
   SlackInboundChannel,
   SlackOutboundChannel,
   SlackSessionPolicy,
+  slackMcpServerConfig,
 } from '@agentry/adapter-channel-slack';
 import type { ChannelKind, OutboundChannel, SessionPolicy } from '@agentry/core';
 import { AgentryConfigSchema, compose, loadSecrets } from '@agentry/runtime';
@@ -54,6 +55,7 @@ async function main(): Promise<void> {
         inboundChannels: [inbound],
         outboundChannels: new Map<ChannelKind, OutboundChannel>([[policy.channelKind, outbound]]),
         sessionPolicies: new Map<ChannelKind, SessionPolicy>([[policy.channelKind, policy]]),
+        mcpServers: [slackMcpServerConfig({ botToken: secrets.SLACK_BOT_TOKEN })],
       };
     },
   });

--- a/packages/adapter-channel-slack/package.json
+++ b/packages/adapter-channel-slack/package.json
@@ -11,17 +11,22 @@
       "import": "./dist/index.js"
     }
   },
+  "bin": {
+    "agentry-slack": "./dist/cli/main.js"
+  },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b && chmod +x dist/cli/main.js dist/mcp/server.js",
     "test": "vitest run"
   },
   "dependencies": {
     "@agentry/core": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@slack/bolt": "^4.7.1",
-    "@slack/web-api": "^7.15.1"
+    "@slack/web-api": "^7.15.1",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^24.12.2"

--- a/packages/adapter-channel-slack/src/cli/cli.test.ts
+++ b/packages/adapter-channel-slack/src/cli/cli.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runSlackCli } from './cli.js';
+
+interface CapturedIo {
+  readonly out: string[];
+  readonly err: string[];
+  readonly io: { out: (msg: string) => void; err: (msg: string) => void };
+}
+
+function captureIo(): CapturedIo {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    io: {
+      out: (msg) => out.push(msg),
+      err: (msg) => err.push(msg),
+    },
+  };
+}
+
+function fakeFetch(init: {
+  readonly status?: number;
+  readonly grantedScopes: string;
+  readonly body: { ok: boolean; user_id?: string; team_id?: string; error?: string };
+}): typeof globalThis.fetch {
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify(init.body), {
+        status: init.status ?? 200,
+        headers: { 'x-oauth-scopes': init.grantedScopes },
+      }),
+  ) as unknown as typeof globalThis.fetch;
+}
+
+describe('runSlackCli', () => {
+  it('prints usage and returns 1 on unknown command', async () => {
+    const cap = captureIo();
+    const code = await runSlackCli([], {}, cap.io);
+    expect(code).toBe(1);
+    expect(cap.err.join('\n')).toContain('Usage');
+  });
+
+  it('verify-scopes returns 1 when SLACK_BOT_TOKEN is missing', async () => {
+    const cap = captureIo();
+    const code = await runSlackCli(['verify-scopes'], {}, cap.io);
+    expect(code).toBe(1);
+    expect(cap.err.join('\n')).toContain('SLACK_BOT_TOKEN');
+  });
+
+  it('verify-scopes returns 0 with bot identity line when all scopes are present', async () => {
+    const cap = captureIo();
+    const fetch = fakeFetch({
+      grantedScopes: 'app_mentions:read,chat:write,channels:history,groups:history',
+      body: { ok: true, user_id: 'U-BOT', team_id: 'T-TEAM' },
+    });
+
+    const code = await runSlackCli(
+      ['verify-scopes'],
+      { SLACK_BOT_TOKEN: 'xoxb-test' },
+      cap.io,
+      fetch,
+    );
+
+    expect(code).toBe(0);
+    expect(cap.out.join('\n')).toContain('U-BOT');
+    expect(cap.out.join('\n')).toContain('T-TEAM');
+  });
+
+  it('verify-scopes returns 1 with the missing-scope message when a scope is absent', async () => {
+    const cap = captureIo();
+    const fetch = fakeFetch({
+      grantedScopes: 'app_mentions:read,chat:write',
+      body: { ok: true, user_id: 'U-BOT', team_id: 'T-TEAM' },
+    });
+
+    const code = await runSlackCli(
+      ['verify-scopes'],
+      { SLACK_BOT_TOKEN: 'xoxb-test' },
+      cap.io,
+      fetch,
+    );
+
+    expect(code).toBe(1);
+    expect(cap.err.join('\n')).toContain('channels:history');
+  });
+});

--- a/packages/adapter-channel-slack/src/cli/cli.ts
+++ b/packages/adapter-channel-slack/src/cli/cli.ts
@@ -1,0 +1,66 @@
+import { SLACK_REQUIRED_SCOPES } from '../slack-inbound-channel.js';
+import { SlackScopeError, verifySlackScopes } from '../slack-scope-verifier.js';
+
+const USAGE = `Usage: agentry-slack <command>
+
+Commands:
+  verify-scopes    Verify SLACK_BOT_TOKEN has all required OAuth scopes.
+                   Required env: SLACK_BOT_TOKEN
+`;
+
+export interface RunSlackCliIo {
+  readonly out: (msg: string) => void;
+  readonly err: (msg: string) => void;
+}
+
+const DEFAULT_IO: RunSlackCliIo = {
+  out: (msg) => {
+    console.log(msg);
+  },
+  err: (msg) => {
+    console.error(msg);
+  },
+};
+
+export async function runSlackCli(
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+  io: RunSlackCliIo = DEFAULT_IO,
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+): Promise<number> {
+  const command = argv[0];
+
+  if (command === 'verify-scopes') {
+    return verifyScopesCommand(env, io, fetchImpl);
+  }
+
+  io.err(USAGE);
+  return 1;
+}
+
+async function verifyScopesCommand(
+  env: NodeJS.ProcessEnv,
+  io: RunSlackCliIo,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<number> {
+  const token = env.SLACK_BOT_TOKEN;
+  if (token === undefined || token.length === 0) {
+    io.err('SLACK_BOT_TOKEN must be set in the environment');
+    return 1;
+  }
+
+  try {
+    const info = await verifySlackScopes(token, SLACK_REQUIRED_SCOPES, fetchImpl);
+    io.out(
+      `verify-scopes ok — bot ${info.botUserId} in team ${info.teamId} has all ${SLACK_REQUIRED_SCOPES.length} required scopes`,
+    );
+    return 0;
+  } catch (err) {
+    if (err instanceof SlackScopeError) {
+      io.err(err.message);
+      return 1;
+    }
+    io.err(`verify-scopes failed: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}

--- a/packages/adapter-channel-slack/src/cli/main.ts
+++ b/packages/adapter-channel-slack/src/cli/main.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+import { runSlackCli } from './cli.js';
+
+runSlackCli(process.argv.slice(2)).then(
+  (code) => process.exit(code),
+  (err: unknown) => {
+    console.error(err);
+    process.exit(1);
+  },
+);

--- a/packages/adapter-channel-slack/src/index.ts
+++ b/packages/adapter-channel-slack/src/index.ts
@@ -22,6 +22,11 @@ export {
   type SlackInboundChannelOptions,
 } from './slack-inbound-channel.js';
 export {
+  SLACK_MCP_SERVER_NAME,
+  type SlackMcpServerConfigOptions,
+  slackMcpServerConfig,
+} from './slack-mcp-config.js';
+export {
   SlackOutboundChannel,
   SlackOutboundChannelError,
   type SlackOutboundChannelOptions,

--- a/packages/adapter-channel-slack/src/mcp/server.test.ts
+++ b/packages/adapter-channel-slack/src/mcp/server.test.ts
@@ -1,0 +1,30 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Resolves to `packages/adapter-channel-slack/dist/mcp/server.js`.
+// Skipped when the package hasn't been built — local dev runs vitest before
+// `pnpm build`. CI runs build first.
+const here = dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = join(here, '..', '..', 'dist', 'mcp', 'server.js');
+const built = existsSync(SERVER_PATH);
+
+describe.skipIf(!built)('mcp/server.js (built)', () => {
+  // Stdout is the MCP protocol channel. Even one accidental `console.log`
+  // from our code (or any imported module) would break the JSON-RPC framing
+  // on the Claude CLI side. The fail-fast SLACK_BOT_TOKEN check exits BEFORE
+  // any transport opens, so stdout MUST be empty in that path.
+  it('writes nothing to stdout when SLACK_BOT_TOKEN is missing', () => {
+    const result = spawnSync(process.execPath, [SERVER_PATH], {
+      env: { PATH: process.env.PATH ?? '' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      encoding: 'utf8',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('SLACK_BOT_TOKEN');
+  });
+});

--- a/packages/adapter-channel-slack/src/mcp/server.ts
+++ b/packages/adapter-channel-slack/src/mcp/server.ts
@@ -1,0 +1,55 @@
+// stdio MCP server entry. Spawned by Claude CLI when listed under
+// `--mcp-config`. CRITICAL: stdout is the protocol channel — we MUST NOT
+// write to stdout from this file or anything it imports. All logging goes to
+// stderr.
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { WebClient } from '@slack/web-api';
+import { SLACK_MCP_SERVER_NAME } from '../slack-mcp-config.js';
+import {
+  getChannelHistory,
+  getChannelHistoryInputShape,
+  SLACK_GET_CHANNEL_HISTORY_TOOL_NAME,
+} from './tools/get-channel-history.js';
+
+const SERVER_VERSION = '0.0.0';
+
+async function main(): Promise<void> {
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (token === undefined || token.length === 0) {
+    process.stderr.write(`${SLACK_MCP_SERVER_NAME}: SLACK_BOT_TOKEN env var is required\n`);
+    process.exit(1);
+  }
+
+  const client = new WebClient(token);
+  const server = new McpServer(
+    { name: SLACK_MCP_SERVER_NAME, version: SERVER_VERSION },
+    {
+      capabilities: { tools: {} },
+      instructions:
+        'Tools for reading Slack channel context. Bot-authored messages are preserved with bot_id intact so the agent can reason about content posted by other bots in the same channel.',
+    },
+  );
+
+  server.registerTool(
+    SLACK_GET_CHANNEL_HISTORY_TOOL_NAME,
+    {
+      description:
+        'Read recent messages from a Slack channel the bot is a member of. Returns most recent first. Bot-authored messages are included; their bot_id field is preserved so the agent can distinguish them from human messages.',
+      inputSchema: getChannelHistoryInputShape,
+    },
+    async (args) => getChannelHistory(client, args),
+  );
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.stderr.write(`${SLACK_MCP_SERVER_NAME} v${SERVER_VERSION} running on stdio\n`);
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `${SLACK_MCP_SERVER_NAME}: fatal error: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/packages/adapter-channel-slack/src/mcp/tools/get-channel-history.test.ts
+++ b/packages/adapter-channel-slack/src/mcp/tools/get-channel-history.test.ts
@@ -1,0 +1,93 @@
+import type { WebClient } from '@slack/web-api';
+import { describe, expect, it, vi } from 'vitest';
+import { getChannelHistory } from './get-channel-history.js';
+
+interface FakeHistoryResponse {
+  readonly ok: boolean;
+  readonly error?: string;
+  readonly messages?: readonly Record<string, unknown>[];
+}
+
+function fakeClient(responses: {
+  history: (req: Record<string, unknown>) => Promise<FakeHistoryResponse>;
+}): WebClient {
+  return {
+    conversations: { history: vi.fn(responses.history) },
+  } as unknown as WebClient;
+}
+
+describe('getChannelHistory', () => {
+  it('returns messages with bot_id preserved', async () => {
+    const client = fakeClient({
+      history: async () => ({
+        ok: true,
+        messages: [
+          { ts: '1.0', user: 'U1', text: 'hello' },
+          { ts: '2.0', bot_id: 'B999', username: 'workflow-bot', text: 'QA report' },
+          { ts: '3.0', user: 'U2', text: 'reply', thread_ts: '1.0' },
+        ],
+      }),
+    });
+
+    const result = await getChannelHistory(client, { channel: 'C123' });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toHaveLength(1);
+    const payload = JSON.parse(result.content[0].text) as {
+      messages: readonly Record<string, unknown>[];
+    };
+    expect(payload.messages).toEqual([
+      { ts: '1.0', user: 'U1', text: 'hello' },
+      { ts: '2.0', bot_id: 'B999', username: 'workflow-bot', text: 'QA report' },
+      { ts: '3.0', user: 'U2', text: 'reply', thread_ts: '1.0' },
+    ]);
+  });
+
+  it('passes limit and since through to Slack', async () => {
+    const historyMock = vi.fn(async () => ({ ok: true, messages: [] }));
+    const client = fakeClient({ history: historyMock });
+
+    await getChannelHistory(client, { channel: 'C123', limit: 25, since: 1700000000 });
+
+    expect(historyMock).toHaveBeenCalledWith({
+      channel: 'C123',
+      limit: 25,
+      oldest: '1700000000',
+    });
+  });
+
+  it('uses default limit when none is provided', async () => {
+    const historyMock = vi.fn(async () => ({ ok: true, messages: [] }));
+    const client = fakeClient({ history: historyMock });
+
+    await getChannelHistory(client, { channel: 'C123' });
+
+    const call = historyMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(call.limit).toBe(50);
+    expect(call.oldest).toBeUndefined();
+  });
+
+  it('returns isError=true when Slack responds with !ok', async () => {
+    const client = fakeClient({
+      history: async () => ({ ok: false, error: 'channel_not_found' }),
+    });
+
+    const result = await getChannelHistory(client, { channel: 'C123' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('channel_not_found');
+  });
+
+  it('returns isError=true when the underlying call throws', async () => {
+    const client = fakeClient({
+      history: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    const result = await getChannelHistory(client, { channel: 'C123' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('network down');
+  });
+});

--- a/packages/adapter-channel-slack/src/mcp/tools/get-channel-history.ts
+++ b/packages/adapter-channel-slack/src/mcp/tools/get-channel-history.ts
@@ -1,0 +1,92 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { WebClient } from '@slack/web-api';
+import { z } from 'zod';
+
+export const SLACK_GET_CHANNEL_HISTORY_TOOL_NAME = 'slack_get_channel_history';
+
+// Raw shape — the MCP SDK's `registerTool` consumes this directly.
+export const getChannelHistoryInputShape = {
+  channel: z
+    .string()
+    .min(1)
+    .describe('Slack channel ID (e.g. C0123456). The bot must already be a member of the channel.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe('Maximum number of messages to return. Default 50, max 200.'),
+  since: z
+    .number()
+    .optional()
+    .describe(
+      'Unix timestamp (seconds). When set, only messages posted at or after this time are returned.',
+    ),
+};
+
+const InputSchema = z.object(getChannelHistoryInputShape);
+export type GetChannelHistoryInput = z.infer<typeof InputSchema>;
+
+const DEFAULT_LIMIT = 50;
+
+// Bot-authored messages (bot_id present) are intentionally preserved here —
+// this tool feeds the running agent's context, where seeing what other bots
+// posted in the same channel is the killer use case (#26).
+export interface SlackHistoryMessage {
+  readonly ts: string;
+  readonly user?: string;
+  readonly bot_id?: string;
+  readonly username?: string;
+  readonly text: string;
+  readonly thread_ts?: string;
+}
+
+export async function getChannelHistory(
+  client: WebClient,
+  args: GetChannelHistoryInput,
+): Promise<CallToolResult> {
+  try {
+    const res = await client.conversations.history({
+      channel: args.channel,
+      limit: args.limit ?? DEFAULT_LIMIT,
+      ...(args.since !== undefined ? { oldest: String(args.since) } : {}),
+    });
+    if (!res.ok || !res.messages) {
+      return errorResult(`Slack API error: ${res.error ?? 'unknown'}`);
+    }
+    const messages: SlackHistoryMessage[] = res.messages.map(toHistoryMessage);
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ messages }) }],
+    };
+  } catch (err) {
+    return errorResult(
+      `Slack API call failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function toHistoryMessage(m: {
+  readonly ts?: string;
+  readonly user?: string;
+  readonly bot_id?: string;
+  readonly username?: string;
+  readonly text?: string;
+  readonly thread_ts?: string;
+}): SlackHistoryMessage {
+  return {
+    ts: m.ts ?? '',
+    ...(m.user !== undefined ? { user: m.user } : {}),
+    ...(m.bot_id !== undefined ? { bot_id: m.bot_id } : {}),
+    ...(m.username !== undefined ? { username: m.username } : {}),
+    text: m.text ?? '',
+    ...(m.thread_ts !== undefined ? { thread_ts: m.thread_ts } : {}),
+  };
+}
+
+function errorResult(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}

--- a/packages/adapter-channel-slack/src/slack-mcp-config.test.ts
+++ b/packages/adapter-channel-slack/src/slack-mcp-config.test.ts
@@ -1,0 +1,23 @@
+import { join, sep } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SLACK_MCP_SERVER_NAME, slackMcpServerConfig } from './slack-mcp-config.js';
+
+describe('slackMcpServerConfig', () => {
+  it('produces a McpServerConfig with the bot token in env', () => {
+    const config = slackMcpServerConfig({ botToken: 'xoxb-test-1234' });
+
+    expect(config.name).toBe(SLACK_MCP_SERVER_NAME);
+    expect(config.name).toBe('agentry-slack');
+    expect(config.command).toBe(process.execPath);
+    expect(config.env).toEqual({ SLACK_BOT_TOKEN: 'xoxb-test-1234' });
+  });
+
+  it('points args at a sibling mcp/server.js path', () => {
+    const config = slackMcpServerConfig({ botToken: 't' });
+
+    expect(config.args).toHaveLength(1);
+    const serverPath = config.args?.[0] ?? '';
+    expect(serverPath.endsWith(join('mcp', 'server.js'))).toBe(true);
+    expect(serverPath).toContain(sep);
+  });
+});

--- a/packages/adapter-channel-slack/src/slack-mcp-config.ts
+++ b/packages/adapter-channel-slack/src/slack-mcp-config.ts
@@ -1,0 +1,22 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { McpServerConfig } from '@agentry/core';
+
+export const SLACK_MCP_SERVER_NAME = 'agentry-slack';
+
+export interface SlackMcpServerConfigOptions {
+  readonly botToken: string;
+}
+
+// Resolves the MCP server entry path via `import.meta.url` so it lands on
+// `dist/mcp/server.js` (the sibling of the compiled `dist/slack-mcp-config.js`).
+export function slackMcpServerConfig(opts: SlackMcpServerConfigOptions): McpServerConfig {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const serverPath = join(here, 'mcp', 'server.js');
+  return {
+    name: SLACK_MCP_SERVER_NAME,
+    command: process.execPath,
+    args: [serverPath],
+    env: { SLACK_BOT_TOKEN: opts.botToken },
+  };
+}

--- a/packages/adapter-channel-slack/src/slack-session-policy.test.ts
+++ b/packages/adapter-channel-slack/src/slack-session-policy.test.ts
@@ -39,4 +39,22 @@ describe('SlackSessionPolicy', () => {
     expect(policy.shouldEndOn({ kind: 'idle_timeout' })).toBe(false);
     expect(policy.shouldEndOn({ kind: 'user_left' })).toBe(false);
   });
+
+  it('exposes channelId + threadTs as agent context', () => {
+    const ctx = policy.toAgentContext(buildEvent('slack:C1:1.0'));
+    expect(ctx).toEqual({ channelId: 'C1', threadTs: '1.0' });
+  });
+
+  it('omits keys when threading values are missing or non-string', () => {
+    const event: IncomingEvent = {
+      channelKind: 'slack',
+      channelNativeRef: 'slack:?:?',
+      author: { channelUserId: 'U1' },
+      payload: { text: 'hi' },
+      threading: {},
+      receivedAt: new Date(0),
+      idempotencyKey: 'Ev1',
+    };
+    expect(policy.toAgentContext(event)).toEqual({});
+  });
 });

--- a/packages/adapter-channel-slack/src/slack-session-policy.ts
+++ b/packages/adapter-channel-slack/src/slack-session-policy.ts
@@ -27,4 +27,13 @@ export class SlackSessionPolicy implements SessionPolicy {
   shouldEndOn(event: SessionLifecycleEvent): boolean {
     return event.kind === 'channel_close';
   }
+
+  toAgentContext(event: IncomingEvent): Readonly<Record<string, string>> {
+    const channel = event.threading.channel;
+    const threadTs = event.threading.thread_ts;
+    const ctx: Record<string, string> = {};
+    if (typeof channel === 'string' && channel.length > 0) ctx.channelId = channel;
+    if (typeof threadTs === 'string' && threadTs.length > 0) ctx.threadTs = threadTs;
+    return ctx;
+  }
 }

--- a/packages/adapter-runner-claude-cli/src/claude-cli-runner.test.ts
+++ b/packages/adapter-runner-claude-cli/src/claude-cli-runner.test.ts
@@ -1,8 +1,11 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import type { AgentEvent } from '@agentry/core';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ClaudeCliAgentRunner } from './claude-cli-runner.js';
 
 class FakeChildProcess extends EventEmitter {
@@ -157,6 +160,102 @@ describe('ClaudeCliAgentRunner', () => {
       { type: 'error', message: 'spawn claude ENOENT', recoverable: false },
       { type: 'finished', reason: 'error', usage: { input: 0, output: 0 } },
     ]);
+  });
+
+  describe('with mcpServers configured', () => {
+    let scratchDir: string;
+
+    beforeEach(() => {
+      scratchDir = mkdtempSync(join(tmpdir(), 'mcp-runner-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(scratchDir, { recursive: true, force: true });
+    });
+
+    it('writes config JSON and adds --mcp-config flag when servers are non-empty', async () => {
+      const fake = new FakeChildProcess();
+      let captured: readonly string[] = [];
+      const configPath = join(scratchDir, 'mcp.json');
+      const runner = new ClaudeCliAgentRunner({
+        spawn: (_cmd, args) => {
+          captured = args;
+          return asChildProcess(fake);
+        },
+        mcpServers: [
+          {
+            name: 'agentry-slack',
+            command: '/usr/bin/node',
+            args: ['/abs/path/server.js'],
+            env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+          },
+        ],
+        mcpConfigPath: configPath,
+      });
+      const events = collect(runner.run(baseInput));
+      fake.pushStdoutLine(
+        '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":0,"output_tokens":0}}',
+      );
+      fake.emitExit(0);
+      await events;
+
+      expect(captured).toContain('--mcp-config');
+      const idx = captured.indexOf('--mcp-config');
+      expect(captured[idx + 1]).toBe(configPath);
+
+      const written = JSON.parse(readFileSync(configPath, 'utf8'));
+      expect(written).toEqual({
+        mcpServers: {
+          'agentry-slack': {
+            command: '/usr/bin/node',
+            args: ['/abs/path/server.js'],
+            env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+          },
+        },
+      });
+
+      const mode = statSync(configPath).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it('omits --mcp-config when mcpServers is undefined', async () => {
+      const fake = new FakeChildProcess();
+      let captured: readonly string[] = [];
+      const runner = new ClaudeCliAgentRunner({
+        spawn: (_cmd, args) => {
+          captured = args;
+          return asChildProcess(fake);
+        },
+      });
+      const events = collect(runner.run(baseInput));
+      fake.pushStdoutLine(
+        '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":0,"output_tokens":0}}',
+      );
+      fake.emitExit(0);
+      await events;
+
+      expect(captured).not.toContain('--mcp-config');
+    });
+
+    it('omits --mcp-config when mcpServers is an empty list', async () => {
+      const fake = new FakeChildProcess();
+      let captured: readonly string[] = [];
+      const runner = new ClaudeCliAgentRunner({
+        spawn: (_cmd, args) => {
+          captured = args;
+          return asChildProcess(fake);
+        },
+        mcpServers: [],
+      });
+      const events = collect(runner.run(baseInput));
+      fake.pushStdoutLine(
+        '{"type":"result","subtype":"success","is_error":false,"usage":{"input_tokens":0,"output_tokens":0}}',
+      );
+      fake.emitExit(0);
+      await events;
+
+      expect(captured).not.toContain('--mcp-config');
+    });
   });
 
   it('emits error + finished{error} when child exits without a result line, including stderr tail', async () => {

--- a/packages/adapter-runner-claude-cli/src/claude-cli-runner.ts
+++ b/packages/adapter-runner-claude-cli/src/claude-cli-runner.ts
@@ -1,6 +1,16 @@
 import { type ChildProcess, spawn as defaultSpawn, type SpawnOptions } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createInterface } from 'node:readline';
-import type { AgentEvent, AgentRunInput, AgentRunner, TokenUsage } from '@agentry/core';
+import type {
+  AgentEvent,
+  AgentRunInput,
+  AgentRunner,
+  McpServerConfig,
+  TokenUsage,
+} from '@agentry/core';
 import { createParserState, finishedEvent, parseLine } from './stream-parser.js';
 
 export type SpawnFn = (
@@ -12,6 +22,12 @@ export type SpawnFn = (
 export interface ClaudeCliAgentRunnerOptions {
   readonly claudeBinary?: string;
   readonly spawn?: SpawnFn;
+  readonly mcpServers?: readonly McpServerConfig[];
+  // Test seam: when supplied, the runner writes to this path and skips the
+  // process-exit cleanup hook (the test owns lifecycle of the file). In
+  // production the runner generates a path under `os.tmpdir()` and registers
+  // its own cleanup.
+  readonly mcpConfigPath?: string;
 }
 
 const ZERO_USAGE: TokenUsage = { input: 0, output: 0 };
@@ -27,13 +43,25 @@ const BASE_CLI_ARGS = [
 
 export class ClaudeCliAgentRunner implements AgentRunner {
   readonly kind = 'claude_cli';
+  private readonly mcpConfigPath: string | undefined;
 
-  constructor(private readonly options: ClaudeCliAgentRunnerOptions = {}) {}
+  constructor(private readonly options: ClaudeCliAgentRunnerOptions = {}) {
+    const servers = options.mcpServers;
+    if (servers !== undefined && servers.length > 0) {
+      const callerOwnsPath = options.mcpConfigPath !== undefined;
+      const configPath = options.mcpConfigPath ?? defaultMcpConfigPath();
+      writeMcpConfigJson(configPath, servers);
+      if (!callerOwnsPath) registerMcpConfigCleanup(configPath);
+      this.mcpConfigPath = configPath;
+    } else {
+      this.mcpConfigPath = undefined;
+    }
+  }
 
   async *run(input: AgentRunInput): AsyncIterable<AgentEvent> {
     const binary = this.options.claudeBinary ?? 'claude';
     const spawnFn = this.options.spawn ?? defaultSpawn;
-    const args = buildArgs(input);
+    const args = buildArgs(input, this.mcpConfigPath);
 
     const child = spawnFn(binary, args, {
       cwd: input.workdir,
@@ -119,7 +147,45 @@ export class ClaudeCliAgentRunner implements AgentRunner {
   }
 }
 
-function buildArgs(input: AgentRunInput): readonly string[] {
-  if (input.resumeKey === undefined) return BASE_CLI_ARGS;
-  return [...BASE_CLI_ARGS, '--resume', input.resumeKey];
+function buildArgs(input: AgentRunInput, mcpConfigPath: string | undefined): readonly string[] {
+  const args: string[] = [...BASE_CLI_ARGS];
+  if (mcpConfigPath !== undefined) {
+    args.push('--mcp-config', mcpConfigPath);
+  }
+  if (input.resumeKey !== undefined) {
+    args.push('--resume', input.resumeKey);
+  }
+  return args;
+}
+
+function defaultMcpConfigPath(): string {
+  return join(tmpdir(), `agentry-mcp-${process.pid}-${randomUUID()}.json`);
+}
+
+interface ClaudeMcpServerJson {
+  readonly command: string;
+  readonly args?: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+function writeMcpConfigJson(filePath: string, servers: readonly McpServerConfig[]): void {
+  const entries: Record<string, ClaudeMcpServerJson> = {};
+  for (const s of servers) {
+    entries[s.name] = {
+      command: s.command,
+      ...(s.args !== undefined ? { args: s.args } : {}),
+      ...(s.env !== undefined ? { env: s.env } : {}),
+    };
+  }
+  writeFileSync(filePath, JSON.stringify({ mcpServers: entries }), { mode: 0o600 });
+}
+
+function registerMcpConfigCleanup(filePath: string): void {
+  process.once('exit', () => {
+    try {
+      unlinkSync(filePath);
+    } catch {
+      // best effort — file may have been removed already
+    }
+  });
 }

--- a/packages/core/src/app/handle-incoming-message.ts
+++ b/packages/core/src/app/handle-incoming-message.ts
@@ -27,6 +27,11 @@ export type HandleIncomingMessage = (event: IncomingEvent) => Promise<void>;
 
 const DEFAULT_TOP_K = 5;
 
+// Header for the optional channel-context block prepended to the agent
+// prompt. Kept as an exported constant so seed/agent-workdir/CLAUDE.md can
+// refer to it by name and stay in sync if it changes.
+export const CHANNEL_CONTEXT_HEADER = '[Channel context]';
+
 interface ProcessOneTurnArgs {
   readonly event: IncomingEvent;
   readonly sessionId: SessionId;
@@ -34,6 +39,7 @@ interface ProcessOneTurnArgs {
   readonly log: Logger;
   readonly deps: HandleIncomingMessageDeps;
   readonly topK: number;
+  readonly policy: SessionPolicy;
 }
 
 export function makeHandleIncomingMessage(deps: HandleIncomingMessageDeps): HandleIncomingMessage {
@@ -61,9 +67,19 @@ export function makeHandleIncomingMessage(deps: HandleIncomingMessageDeps): Hand
 
     await deps.jobRunner.enqueue({
       key: session.id,
-      job: () => processOneTurn({ event, sessionId: session.id, tenantId, log, deps, topK }),
+      job: () =>
+        processOneTurn({ event, sessionId: session.id, tenantId, log, deps, topK, policy }),
     });
   };
+}
+
+function buildAgentPrompt(event: IncomingEvent, policy: SessionPolicy): string {
+  const ctx = policy.toAgentContext?.(event);
+  if (!ctx) return event.payload.text;
+  const keys = Object.keys(ctx);
+  if (keys.length === 0) return event.payload.text;
+  const lines = keys.map((k) => `- ${k}: ${ctx[k]}`).join('\n');
+  return `${CHANNEL_CONTEXT_HEADER}\n${lines}\n\n${event.payload.text}`;
 }
 
 async function processOneTurn(args: ProcessOneTurnArgs): Promise<void> {
@@ -106,7 +122,7 @@ async function processOneTurn(args: ProcessOneTurnArgs): Promise<void> {
     for await (const ev of deps.agentRunner.run({
       sessionId,
       workdir: deps.agentWorkdir,
-      prompt: event.payload.text,
+      prompt: buildAgentPrompt(event, args.policy),
       context: { retrievedKnowledge },
     })) {
       if (ev.type === 'text_delta') {

--- a/packages/core/src/app/index.ts
+++ b/packages/core/src/app/index.ts
@@ -2,4 +2,4 @@ export type {
   HandleIncomingMessage,
   HandleIncomingMessageDeps,
 } from './handle-incoming-message.js';
-export { makeHandleIncomingMessage } from './handle-incoming-message.js';
+export { CHANNEL_CONTEXT_HEADER, makeHandleIncomingMessage } from './handle-incoming-message.js';

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -23,6 +23,7 @@ export type {
   ProvenanceRef,
   SourceType,
 } from './knowledge.js';
+export type { McpServerConfig } from './mcp-server.js';
 export type {
   ItemFilter,
   RetrievalMode,

--- a/packages/core/src/domain/mcp-server.ts
+++ b/packages/core/src/domain/mcp-server.ts
@@ -1,0 +1,13 @@
+// Description of a stdio-transport MCP server an adapter wants registered with
+// the agent runtime. The runtime serializes a list of these into the JSON the
+// agent runner hands to Claude CLI via `--mcp-config`.
+//
+// Adapters MUST namespace `name` under `agentry-*` (e.g. `agentry-slack`).
+// Names without that prefix are reserved for user-supplied entries discovered
+// from the agent workdir's own `.mcp.json`.
+export interface McpServerConfig {
+  readonly name: string;
+  readonly command: string;
+  readonly args?: readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+}

--- a/packages/core/src/ports/session-policy.ts
+++ b/packages/core/src/ports/session-policy.ts
@@ -18,4 +18,9 @@ export interface SessionPolicy {
   computeNativeRef(event: IncomingEvent): ChannelNativeRef;
   idleTimeoutMinutes(): number;
   shouldEndOn(event: SessionLifecycleEvent): boolean;
+  // Optional: agent-facing context (channel id, thread id, ...). Returned
+  // values are prepended to the agent prompt under `CHANNEL_CONTEXT_HEADER`
+  // so the agent can resolve "this channel"-style references when calling
+  // adapter MCP tools. Empty / missing → no header in prompt.
+  toAgentContext?(event: IncomingEvent): Readonly<Record<string, string>>;
 }

--- a/packages/runtime/src/compose.test.ts
+++ b/packages/runtime/src/compose.test.ts
@@ -234,4 +234,35 @@ describe('compose', () => {
     expect(handles.inboundChannels).toEqual([]);
     await handles.shutdown();
   });
+
+  it('forwards mcpServers from buildChannels to ClaudeCliAgentRunner spawn args', async () => {
+    const { asPool } = makeStubPool();
+    const spawn = vi.fn(() => {
+      throw new Error('spawn should not run during this test');
+    });
+
+    const handles = await compose({
+      config,
+      secrets,
+      poolFactory: () => asPool,
+      spawn: spawn as never,
+      buildChannels: () => ({
+        mcpServers: [
+          {
+            name: 'agentry-slack',
+            command: '/usr/bin/node',
+            args: ['/abs/path/server.js'],
+            env: { SLACK_BOT_TOKEN: 'xoxb' },
+          },
+        ],
+      }),
+    });
+
+    // The agentRunner just exposes its kind; verifying the tempfile creation
+    // is owned by ClaudeCliAgentRunner's own tests. Here we assert compose
+    // accepted the option without error (a dropped option would surface as
+    // either a typecheck or a missing flag in the runner unit tests).
+    expect(handles.agentRunner.kind).toBe('claude_cli');
+    await handles.shutdown();
+  });
 });

--- a/packages/runtime/src/compose.ts
+++ b/packages/runtime/src/compose.ts
@@ -13,6 +13,7 @@ import type {
   JobRunner,
   KnowledgeStore,
   Logger,
+  McpServerConfig,
   OutboundChannel,
   SessionPolicy,
   SessionStore,
@@ -31,6 +32,9 @@ export interface BuildChannelsResult {
   readonly inboundChannels?: readonly InboundChannel[];
   readonly outboundChannels?: ReadonlyMap<ChannelKind, OutboundChannel>;
   readonly sessionPolicies?: ReadonlyMap<ChannelKind, SessionPolicy>;
+  // Per ARCHITECTURE.md §11.1 — channel-adapter MCP servers the runtime
+  // forwards to the agent runner.
+  readonly mcpServers?: readonly McpServerConfig[];
 }
 
 export interface ComposeArgs {
@@ -94,10 +98,6 @@ export async function compose(args: ComposeArgs): Promise<RuntimeHandles> {
     embeddings: embeddingProvider,
   });
 
-  const agentRunner = new ClaudeCliAgentRunner(
-    args.spawn !== undefined ? { spawn: args.spawn } : {},
-  );
-
   const jobRunner = new InMemoryJobRunner({
     onError: (err, key) => {
       logger.error({ err, key }, 'job failed');
@@ -108,6 +108,12 @@ export async function compose(args: ComposeArgs): Promise<RuntimeHandles> {
   const inboundChannels = built?.inboundChannels ?? args.inboundChannels ?? [];
   const outboundChannels = built?.outboundChannels ?? args.outboundChannels ?? new Map();
   const sessionPolicies = built?.sessionPolicies ?? args.sessionPolicies ?? new Map();
+  const mcpServers = built?.mcpServers ?? [];
+
+  const agentRunner = new ClaudeCliAgentRunner({
+    ...(args.spawn !== undefined ? { spawn: args.spawn } : {}),
+    ...(mcpServers.length > 0 ? { mcpServers } : {}),
+  });
 
   const handleIncoming = makeHandleIncomingMessage({
     sessionStore,

--- a/packages/testing/src/app/handle-incoming-message.test.ts
+++ b/packages/testing/src/app/handle-incoming-message.test.ts
@@ -8,7 +8,7 @@ import type {
   OutboundChannel,
   SessionPolicy,
 } from '@agentry/core';
-import { makeHandleIncomingMessage } from '@agentry/core';
+import { CHANNEL_CONTEXT_HEADER, makeHandleIncomingMessage } from '@agentry/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { RecordingAgentRunner } from '../agent-runner/recording-agent-runner.js';
 import { RecordingOutboundChannel } from '../channels/recording-outbound-channel.js';
@@ -121,6 +121,76 @@ describe('makeHandleIncomingMessage', () => {
     expect(harness.outbound.replies).toHaveLength(1);
     expect(harness.outbound.replies[0]?.content).toEqual({ text: 'reply' });
     expect(harness.errors).toHaveLength(0);
+  });
+
+  it('passes the user text unchanged when policy.toAgentContext is undefined or empty', async () => {
+    const recorder = new RecordingAgentRunner([
+      { type: 'text_delta', text: 'reply' },
+      { type: 'finished', reason: 'complete', usage: { input: 0, output: 0 } },
+    ]);
+    const h = buildHarness({ agentRunner: recorder });
+
+    await h.handle(makeEvent({ payload: { text: 'plain text' } }));
+    await h.jobRunner.drain();
+
+    expect(recorder.inputs).toHaveLength(1);
+    expect(recorder.inputs[0]?.prompt).toBe('plain text');
+    expect(recorder.inputs[0]?.prompt).not.toContain(CHANNEL_CONTEXT_HEADER);
+  });
+
+  it('prepends a channel-context block when policy returns non-empty context', async () => {
+    const recorder = new RecordingAgentRunner([
+      { type: 'text_delta', text: 'reply' },
+      { type: 'finished', reason: 'complete', usage: { input: 0, output: 0 } },
+    ]);
+    const policyWithCtx = new StaticSessionPolicy({
+      channelKind: 'test',
+      agentContext: { channelId: 'C123', threadTs: '9.7' },
+    });
+    const h = buildHarness({
+      agentRunner: recorder,
+      sessionPolicies: new Map([['test', policyWithCtx]]),
+    });
+
+    await h.handle(makeEvent({ payload: { text: 'summarize this channel' } }));
+    await h.jobRunner.drain();
+
+    const prompt = recorder.inputs[0]?.prompt ?? '';
+    expect(prompt).toContain(CHANNEL_CONTEXT_HEADER);
+    expect(prompt).toContain('channelId: C123');
+    expect(prompt).toContain('threadTs: 9.7');
+    expect(prompt).toContain('summarize this channel');
+    expect(prompt.indexOf(CHANNEL_CONTEXT_HEADER)).toBeLessThan(
+      prompt.indexOf('summarize this channel'),
+    );
+  });
+
+  it('prepends the same context on every turn so resume flow keeps the prompt structure', async () => {
+    const recorder = new RecordingAgentRunner([
+      { type: 'text_delta', text: 'reply' },
+      { type: 'finished', reason: 'complete', usage: { input: 0, output: 0 } },
+    ]);
+    const policyWithCtx = new StaticSessionPolicy({
+      channelKind: 'test',
+      agentContext: { channelId: 'C123', threadTs: '9.7' },
+    });
+    const h = buildHarness({
+      agentRunner: recorder,
+      sessionPolicies: new Map([['test', policyWithCtx]]),
+    });
+
+    await h.handle(makeEvent({ payload: { text: 'first' } }));
+    await h.jobRunner.drain();
+    await h.handle(makeEvent({ payload: { text: 'second' } }));
+    await h.jobRunner.drain();
+
+    expect(recorder.inputs).toHaveLength(2);
+    for (const input of recorder.inputs) {
+      expect(input.prompt).toContain(CHANNEL_CONTEXT_HEADER);
+      expect(input.prompt).toContain('channelId: C123');
+    }
+    expect(recorder.inputs[0]?.prompt).toContain('first');
+    expect(recorder.inputs[1]?.prompt).toContain('second');
   });
 
   it('only records user turn for synthetic events (history-only)', async () => {

--- a/packages/testing/src/session-policy/static-session-policy.ts
+++ b/packages/testing/src/session-policy/static-session-policy.ts
@@ -11,6 +11,9 @@ export interface StaticSessionPolicyOptions {
   readonly idleTimeoutMinutes?: number;
   readonly endOnKinds?: readonly string[];
   readonly resolveNativeRef?: (event: IncomingEvent) => ChannelNativeRef;
+  readonly agentContext?:
+    | Readonly<Record<string, string>>
+    | ((event: IncomingEvent) => Readonly<Record<string, string>>);
 }
 
 export class StaticSessionPolicy implements SessionPolicy {
@@ -18,12 +21,17 @@ export class StaticSessionPolicy implements SessionPolicy {
   private readonly idleTimeout: number;
   private readonly endKinds: ReadonlySet<string>;
   private readonly resolver: (event: IncomingEvent) => ChannelNativeRef;
+  private readonly contextFn?: (event: IncomingEvent) => Readonly<Record<string, string>>;
 
   constructor(options: StaticSessionPolicyOptions) {
     this.channelKind = options.channelKind;
     this.idleTimeout = options.idleTimeoutMinutes ?? 30;
     this.endKinds = new Set(options.endOnKinds ?? ['channel_close']);
     this.resolver = options.resolveNativeRef ?? ((e) => e.channelNativeRef);
+    if (options.agentContext !== undefined) {
+      const ctx = options.agentContext;
+      this.contextFn = typeof ctx === 'function' ? ctx : () => ctx;
+    }
   }
 
   computeNativeRef(event: IncomingEvent): ChannelNativeRef {
@@ -36,5 +44,9 @@ export class StaticSessionPolicy implements SessionPolicy {
 
   shouldEndOn(event: SessionLifecycleEvent): boolean {
     return this.endKinds.has(event.kind);
+  }
+
+  toAgentContext(event: IncomingEvent): Readonly<Record<string, string>> {
+    return this.contextFn ? this.contextFn(event) : {};
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,12 +79,18 @@ importers:
       '@agentry/core':
         specifier: workspace:*
         version: link:../core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@slack/bolt':
         specifier: ^4.7.1
         version: 4.7.1(@types/express@5.0.6)
       '@slack/web-api':
         specifier: ^7.15.1
         version: 7.15.1
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^24.12.2
@@ -461,6 +467,16 @@ packages:
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
 
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -770,6 +786,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -974,6 +1001,10 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
     engines: {node: '>=10.0.0'}
@@ -1114,16 +1145,36 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1255,6 +1306,10 @@ packages:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -1293,6 +1348,15 @@ packages:
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -1497,6 +1561,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -1606,6 +1674,10 @@ packages:
     resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
     hasBin: true
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1705,6 +1777,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
@@ -2129,6 +2205,11 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -2304,6 +2385,28 @@ snapshots:
   '@kwsites/file-exists@1.1.1':
     dependencies:
       debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -2634,6 +2737,17 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -2834,6 +2948,11 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   cpu-features@0.0.10:
     dependencies:
       buildcheck: 0.0.7
@@ -3008,7 +3127,18 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.4.1(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:
@@ -3043,7 +3173,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  fast-deep-equal@3.1.3: {}
+
   fast-fifo@1.3.2: {}
+
+  fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3165,6 +3299,8 @@ snapshots:
 
   interpret@3.1.1: {}
 
+  ip-address@10.1.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-core-module@2.16.1:
@@ -3195,6 +3331,12 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jose@6.2.3: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -3348,6 +3490,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
@@ -3453,6 +3597,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 4.0.0
+
+  pkce-challenge@5.0.1: {}
 
   postcss@8.5.10:
     dependencies:
@@ -3573,6 +3719,8 @@ snapshots:
   regexp-tree@0.1.27: {}
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -4012,5 +4160,9 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@4.3.6: {}

--- a/seed/agent-workdir/CLAUDE.md
+++ b/seed/agent-workdir/CLAUDE.md
@@ -30,6 +30,22 @@ Use this tool when the user's question references prior context the agent
 hasn't seen — for example, "summarize today's QA reports" or "what did the
 deploy bot say about the last release".
 
+#### Resolving "this channel"
+
+The user prompt is prefixed with a `[Channel context]` block (header is
+exported from core as `CHANNEL_CONTEXT_HEADER`). When the user says "this
+channel" or otherwise refers to the current channel, read `channelId` from
+that block and pass it as the `channel` argument to
+`slack_get_channel_history`. Example block:
+
+```
+[Channel context]
+- channelId: C0123456
+- threadTs: 1700000000.000100
+
+<user message>
+```
+
 ## Notes for fork maintainers
 
 Default skills, rules, and additional `.mcp.json` registrations are populated

--- a/seed/agent-workdir/CLAUDE.md
+++ b/seed/agent-workdir/CLAUDE.md
@@ -4,6 +4,34 @@ This directory is the default **procedural memory** shipped by the agentry frame
 The composition root copies or mounts it as the agent's working directory at runtime;
 deployments may override per-instance.
 
-This is a placeholder. Default skills, rules, and `.mcp.json` registrations are
-populated as part of Phase 4 (documentation) and Phase 3 sub-issues that ship
-adapter MCP servers.
+## MCP namespace
+
+Framework-managed MCP servers are registered under the `agentry-*` prefix
+(e.g. `agentry-slack`). Avoid that prefix for your own entries — the runtime
+overrides framework-named entries every boot. User-supplied servers in this
+directory's `.mcp.json` load alongside the framework set; `--strict-mcp-config`
+is intentionally NOT used.
+
+## Available framework tools
+
+When the Slack channel adapter is enabled, the runtime registers an
+`agentry-slack` MCP server. The agent can call:
+
+### `slack_get_channel_history`
+
+Read recent messages from a Slack channel the bot is already a member of.
+Returns most recent first. **Bot-authored messages are preserved with their
+`bot_id` field intact** — when another bot (e.g. a workflow bot posting QA
+reports) is active in the same channel, the agent should still cite that bot
+as the author. Distinguish `bot_id` (other bots) from `user` (humans) when
+attributing content in your reply.
+
+Use this tool when the user's question references prior context the agent
+hasn't seen — for example, "summarize today's QA reports" or "what did the
+deploy bot say about the last release".
+
+## Notes for fork maintainers
+
+Default skills, rules, and additional `.mcp.json` registrations are populated
+as part of Phase 4 (documentation). For now this directory holds the framework
+namespace conventions and a list of registered tools.


### PR DESCRIPTION
## Summary

PR1 of issue #26. Ships the framework's first agent-callable tool path:

- **MCP server** in `packages/adapter-channel-slack/src/mcp/` exposing `slack_get_channel_history` (Slack `conversations.history` wrapper). Bot-authored messages are preserved with `bot_id` intact — opposite of `SlackHistoryBackfiller`'s filter, by design (different code paths, different roles: backfiller turns history into user turns and must drop other bots; this tool feeds the live agent's context, where reading other bots is the killer use case).
- **`agentry-slack verify-scopes` CLI** in `packages/adapter-channel-slack/src/cli/`, wraps the existing `verifySlackScopes` for ops use.
- **Generic `--mcp-config` plumbing**: `ClaudeCliAgentRunner` now serializes adapter-supplied MCP servers into a process-private tempfile (`os.tmpdir()`, mode 0600, `process.once('exit')` cleanup) and passes `--mcp-config <path>` on every Claude CLI spawn. Seed `agent-workdir/.mcp.json` is never touched, so user customizations there continue to load alongside framework entries (`--strict-mcp-config` is intentionally NOT used).
- **Channel-agnostic agent context** via new optional `SessionPolicy.toAgentContext(event)` hook. The use case prepends the returned key/value pairs under `CHANNEL_CONTEXT_HEADER` (`[Channel context]`) whenever non-empty. Slack policy returns `{channelId, threadTs}` so the agent can resolve "this channel" references when calling MCP tools. Future adapters (Discord, CLI, HTTP) implement the same hook with their own keys.
- **`McpServerConfig` DTO** lives in `packages/core/src/domain/` so adapters and runtime share the contract without crossing layer boundaries.

## What's NOT in this PR (followup within #26)

- `slack_get_user_info` + `users:read` scope addition — would force a second deployment reinstall after PR2 of #18; deferred.
- `slack_resolve_channel`, `slack_search_messages`.
- CLI: `list-channels`, `send-test-message`.
- SIGINT/SIGTERM tempfile cleanup (current cleanup runs on natural exit; mode 0600 + per-user tempdir limit blast radius).

## Verification

### Unit tests
- `pnpm typecheck` clean.
- `pnpm test` clean (190 passed, 26 skipped). New tests cover: tempfile + flag injection, `mcpServers` undefined / empty / non-empty branches, file mode 0600, JSON env block, MCP server stdout-purity smoke (skipped when `dist/` absent), Slack `toAgentContext`, `CHANNEL_CONTEXT_HEADER` prefix on / off, two-turn resume keeps prefix.
- `pnpm lint` clean (0 errors; 6 pre-existing infos on unchanged files).
- `pnpm depcheck` clean.

### End-to-end (this is the verification that produced the PR's second commit)
First Slack mention exposed a real gap: agent knew the tool exists, read the seed CLAUDE.md guidance, but had no way to learn the channel ID from its prompt — replied asking the user to specify a channel. Added `SessionPolicy.toAgentContext` to fix it. After rebuild, same prompt over Slack:

> 채널 `C0ARSEED0S2`의 최근 메시지 5개 요약입니다 (최신순):
> 1. 방금 (`1777809328`) — 사용자(U044K34GBLP)가 봇(`<@U0B1BQHDW3U>`)에게 ...
> 4. `1777807876` — 봇(U0B1BQHDW3U, **`bot_id: B0B19NPDY06`**) 자신이 `"diag-test"`라는 진단용 메시지를 게시 ...

That single response confirms: tempfile + `--mcp-config` flow → Claude CLI spawned the MCP server → `SLACK_BOT_TOKEN` env block reached the child process → `[Channel context]` prefix flowed through to the agent → agent extracted `channelId` and called the tool → `bot_id` preserved end-to-end. Both turns persisted in pgvector.

E2E also surfaced an unrelated pitfall worth flagging: Node `--env-file=.env` does NOT override variables already exported in the parent shell. If `SLACK_BOT_TOKEN` is exported in the user's shell, `.env` is silently ignored. The smoke recipe doesn't currently warn about this — separate followup if it bites others.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors; 6 infos pre-existing)
- [x] `pnpm test` clean (190 passed, 26 skipped)
- [x] `pnpm depcheck` clean
- [x] Live Slack workspace e2e: agent calls `slack_get_channel_history`, returns summary with `bot_id` preserved, both turns in DB
- [ ] Manual review of `seed/agent-workdir/CLAUDE.md` framing — agent followed the guidance correctly in the e2e run, but the wording is stable enough to reuse for future adapter MCP additions

Refs #26