### PR TITLE
feat(adapter-channel-slack): slack_get_user_info MCP tool + CLI debug commands (#26 PR2)

### DIFF
--- a/docs/recipes/smoke-test.md
+++ b/docs/recipes/smoke-test.md
@@ -38,6 +38,9 @@ oauth_config:
       - chat:write
       - channels:history
       - groups:history
+      - channels:read
+      - groups:read
+      - users:read
 settings:
   event_subscriptions:
     request_url: https://REPLACE_WITH_NGROK_URL.ngrok.io/slack/events
@@ -138,6 +141,11 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm depcheck
 ## 8. Boot the server
 
 ```bash
+# Node `--env-file` does NOT override variables already exported in the
+# parent shell. If a previous session exported these, .env is silently
+# shadowed and the server boots with stale values.
+unset SLACK_BOT_TOKEN SLACK_SIGNING_SECRET POSTGRES_URL VOYAGE_API_KEY
+
 node --env-file=.env apps/server/dist/main.js
 ```
 
@@ -199,7 +207,7 @@ DoD met when:
 | Symptom                                                   | Cause / fix                                                                                                                                                                |
 | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `SecretsValidationError` on startup                       | A required `.env` key is missing or malformed. The error names every offending key.                                                                                        |
-| `missing required scopes`                                 | Reinstall the Slack app — `channels:history` / `groups:history` were added in the PR2 batch and existing installs need to re-grant.                                        |
+| `missing required scopes`                                 | Reinstall the Slack app — the manifest scope set grew across `#18` PR2 (`*:history`) and `#26` PR2 (`channels:read` / `groups:read` / `users:read`); existing installs must re-grant.       |
 | Slack times out / redelivers events                       | Backfill on the inbound hot path can blow the 3s ack budget on large threads (see issue #63). Reduce thread size for the smoke test, or move backfill offline (followup).  |
 | `conversations.replies failed: channel_not_found`         | The bot isn't a member of the channel. `/invite @agentry-smoke` first.                                                                                                     |
 | `vector(1024) does not match embedding dimension N`       | The VoyageEmbeddingProvider model returned a different dim than the column. Re-run migrate with `EMBEDDING_DIM=N` after dropping the DB volume (`docker compose down -v`). |

--- a/packages/adapter-channel-slack/src/cli/cli.test.ts
+++ b/packages/adapter-channel-slack/src/cli/cli.test.ts
@@ -1,5 +1,7 @@
+import type { WebClient } from '@slack/web-api';
 import { describe, expect, it, vi } from 'vitest';
-import { runSlackCli } from './cli.js';
+import { SLACK_REQUIRED_SCOPES } from '../slack-inbound-channel.js';
+import { runSlackCli, type SlackWebClientFactory } from './cli.js';
 
 interface CapturedIo {
   readonly out: string[];
@@ -20,6 +22,8 @@ function captureIo(): CapturedIo {
   };
 }
 
+const ALL_GRANTED_SCOPES = SLACK_REQUIRED_SCOPES.join(',');
+
 function fakeFetch(init: {
   readonly status?: number;
   readonly grantedScopes: string;
@@ -34,55 +38,246 @@ function fakeFetch(init: {
   ) as unknown as typeof globalThis.fetch;
 }
 
+interface FakeWebClientResponses {
+  readonly conversationsList?: (req: Record<string, unknown>) => Promise<{
+    ok: boolean;
+    error?: string;
+    channels?: readonly Record<string, unknown>[];
+  }>;
+  readonly chatPostMessage?: (req: Record<string, unknown>) => Promise<{
+    ok: boolean;
+    ts?: string;
+    error?: string;
+  }>;
+}
+
+function fakeWebClient(responses: FakeWebClientResponses): {
+  factory: SlackWebClientFactory;
+  conversationsList: ReturnType<typeof vi.fn>;
+  chatPostMessage: ReturnType<typeof vi.fn>;
+} {
+  const conversationsList = vi.fn(
+    responses.conversationsList ?? (async () => ({ ok: true, channels: [] })),
+  );
+  const chatPostMessage = vi.fn(
+    responses.chatPostMessage ?? (async () => ({ ok: true, ts: '1.0' })),
+  );
+  const client = {
+    conversations: { list: conversationsList },
+    chat: { postMessage: chatPostMessage },
+  } as unknown as WebClient;
+  return { factory: () => client, conversationsList, chatPostMessage };
+}
+
 describe('runSlackCli', () => {
   it('prints usage and returns 1 on unknown command', async () => {
     const cap = captureIo();
-    const code = await runSlackCli([], {}, cap.io);
+    const code = await runSlackCli([], { env: {}, io: cap.io });
     expect(code).toBe(1);
     expect(cap.err.join('\n')).toContain('Usage');
   });
 
-  it('verify-scopes returns 1 when SLACK_BOT_TOKEN is missing', async () => {
-    const cap = captureIo();
-    const code = await runSlackCli(['verify-scopes'], {}, cap.io);
-    expect(code).toBe(1);
-    expect(cap.err.join('\n')).toContain('SLACK_BOT_TOKEN');
-  });
-
-  it('verify-scopes returns 0 with bot identity line when all scopes are present', async () => {
-    const cap = captureIo();
-    const fetch = fakeFetch({
-      grantedScopes: 'app_mentions:read,chat:write,channels:history,groups:history',
-      body: { ok: true, user_id: 'U-BOT', team_id: 'T-TEAM' },
+  describe('verify-scopes', () => {
+    it('returns 1 when SLACK_BOT_TOKEN is missing', async () => {
+      const cap = captureIo();
+      const code = await runSlackCli(['verify-scopes'], { env: {}, io: cap.io });
+      expect(code).toBe(1);
+      expect(cap.err.join('\n')).toContain('SLACK_BOT_TOKEN');
     });
 
-    const code = await runSlackCli(
-      ['verify-scopes'],
-      { SLACK_BOT_TOKEN: 'xoxb-test' },
-      cap.io,
-      fetch,
-    );
+    it('returns 0 with bot identity line when all scopes are present', async () => {
+      const cap = captureIo();
+      const fetchImpl = fakeFetch({
+        grantedScopes: ALL_GRANTED_SCOPES,
+        body: { ok: true, user_id: 'U-BOT', team_id: 'T-TEAM' },
+      });
 
-    expect(code).toBe(0);
-    expect(cap.out.join('\n')).toContain('U-BOT');
-    expect(cap.out.join('\n')).toContain('T-TEAM');
-  });
+      const code = await runSlackCli(['verify-scopes'], {
+        env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+        io: cap.io,
+        fetchImpl,
+      });
 
-  it('verify-scopes returns 1 with the missing-scope message when a scope is absent', async () => {
-    const cap = captureIo();
-    const fetch = fakeFetch({
-      grantedScopes: 'app_mentions:read,chat:write',
-      body: { ok: true, user_id: 'U-BOT', team_id: 'T-TEAM' },
+      expect(code).toBe(0);
+      expect(cap.out.join('\n')).toContain('U-BOT');
+      expect(cap.out.join('\n')).toContain('T-TEAM');
     });
 
-    const code = await runSlackCli(
-      ['verify-scopes'],
-      { SLACK_BOT_TOKEN: 'xoxb-test' },
-      cap.io,
-      fetch,
-    );
+    it('returns 1 with the missing-scope message when a scope is absent', async () => {
+      const cap = captureIo();
+      // Drop users:read to simulate a partial install.
+      const fetchImpl = fakeFetch({
+        grantedScopes: SLACK_REQUIRED_SCOPES.filter((s) => s !== 'users:read').join(','),
+        body: { ok: true, user_id: 'U-BOT', team_id: 'T-TEAM' },
+      });
 
-    expect(code).toBe(1);
-    expect(cap.err.join('\n')).toContain('channels:history');
+      const code = await runSlackCli(['verify-scopes'], {
+        env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+        io: cap.io,
+        fetchImpl,
+      });
+
+      expect(code).toBe(1);
+      expect(cap.err.join('\n')).toContain('users:read');
+    });
+  });
+
+  describe('list-channels', () => {
+    it('returns 1 when SLACK_BOT_TOKEN is missing', async () => {
+      const cap = captureIo();
+      const code = await runSlackCli(['list-channels'], { env: {}, io: cap.io });
+      expect(code).toBe(1);
+      expect(cap.err.join('\n')).toContain('SLACK_BOT_TOKEN');
+    });
+
+    it('lists only channels where the bot is a member', async () => {
+      const cap = captureIo();
+      const { factory } = fakeWebClient({
+        conversationsList: async () => ({
+          ok: true,
+          channels: [
+            { id: 'C001', name: 'general', is_member: true, is_private: false },
+            { id: 'C002', name: 'random', is_member: false, is_private: false },
+            { id: 'G003', name: 'private-room', is_member: true, is_private: true },
+          ],
+        }),
+      });
+
+      const code = await runSlackCli(['list-channels'], {
+        env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+        io: cap.io,
+        webClientFactory: factory,
+      });
+
+      expect(code).toBe(0);
+      const out = cap.out.join('\n');
+      expect(out).toContain('C001');
+      expect(out).toContain('general');
+      expect(out).toContain('public');
+      expect(out).toContain('G003');
+      expect(out).toContain('private-room');
+      expect(out).toContain('private');
+      expect(out).not.toContain('C002');
+    });
+
+    it('prints a hint when the bot is in zero channels', async () => {
+      const cap = captureIo();
+      const { factory } = fakeWebClient({
+        conversationsList: async () => ({
+          ok: true,
+          channels: [{ id: 'C001', name: 'general', is_member: false, is_private: false }],
+        }),
+      });
+
+      const code = await runSlackCli(['list-channels'], {
+        env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+        io: cap.io,
+        webClientFactory: factory,
+      });
+
+      expect(code).toBe(0);
+      expect(cap.out.join('\n')).toContain('invite the bot');
+    });
+
+    it('returns 1 when conversations.list fails', async () => {
+      const cap = captureIo();
+      const { factory } = fakeWebClient({
+        conversationsList: async () => ({ ok: false, error: 'missing_scope' }),
+      });
+
+      const code = await runSlackCli(['list-channels'], {
+        env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+        io: cap.io,
+        webClientFactory: factory,
+      });
+
+      expect(code).toBe(1);
+      expect(cap.err.join('\n')).toContain('missing_scope');
+    });
+  });
+
+  describe('send-test-message', () => {
+    it('returns 1 when SLACK_BOT_TOKEN is missing', async () => {
+      const cap = captureIo();
+      const code = await runSlackCli(['send-test-message', '--channel', 'C1'], {
+        env: {},
+        io: cap.io,
+      });
+      expect(code).toBe(1);
+      expect(cap.err.join('\n')).toContain('SLACK_BOT_TOKEN');
+    });
+
+    it('returns 1 when --channel is missing', async () => {
+      const cap = captureIo();
+      const { factory } = fakeWebClient({});
+      const code = await runSlackCli(['send-test-message'], {
+        env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+        io: cap.io,
+        webClientFactory: factory,
+      });
+      expect(code).toBe(1);
+      expect(cap.err.join('\n')).toContain('--channel');
+    });
+
+    it('posts with a default text when --text is not provided', async () => {
+      const cap = captureIo();
+      const { factory, chatPostMessage } = fakeWebClient({
+        chatPostMessage: async () => ({ ok: true, ts: '1700000000.000100' }),
+      });
+      const code = await runSlackCli(['send-test-message', '--channel', 'C1'], {
+        env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+        io: cap.io,
+        webClientFactory: factory,
+      });
+      expect(code).toBe(0);
+      expect(cap.out.join('\n')).toContain('1700000000.000100');
+      expect(chatPostMessage).toHaveBeenCalledWith({
+        channel: 'C1',
+        text: 'agentry-slack send-test-message smoke',
+      });
+    });
+
+    it('forwards --text and --thread-ts to chat.postMessage', async () => {
+      const cap = captureIo();
+      const { factory, chatPostMessage } = fakeWebClient({
+        chatPostMessage: async () => ({ ok: true, ts: '2.0' }),
+      });
+      const code = await runSlackCli(
+        [
+          'send-test-message',
+          '--channel',
+          'C1',
+          '--text',
+          'hello',
+          '--thread-ts',
+          '1700000000.000100',
+        ],
+        {
+          env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+          io: cap.io,
+          webClientFactory: factory,
+        },
+      );
+      expect(code).toBe(0);
+      expect(chatPostMessage).toHaveBeenCalledWith({
+        channel: 'C1',
+        text: 'hello',
+        thread_ts: '1700000000.000100',
+      });
+    });
+
+    it('returns 1 when chat.postMessage fails', async () => {
+      const cap = captureIo();
+      const { factory } = fakeWebClient({
+        chatPostMessage: async () => ({ ok: false, error: 'channel_not_found' }),
+      });
+      const code = await runSlackCli(['send-test-message', '--channel', 'C1'], {
+        env: { SLACK_BOT_TOKEN: 'xoxb-test' },
+        io: cap.io,
+        webClientFactory: factory,
+      });
+      expect(code).toBe(1);
+      expect(cap.err.join('\n')).toContain('channel_not_found');
+    });
   });
 });

--- a/packages/adapter-channel-slack/src/cli/cli.ts
+++ b/packages/adapter-channel-slack/src/cli/cli.ts
@@ -1,11 +1,21 @@
+import { WebClient } from '@slack/web-api';
 import { SLACK_REQUIRED_SCOPES } from '../slack-inbound-channel.js';
 import { SlackScopeError, verifySlackScopes } from '../slack-scope-verifier.js';
 
-const USAGE = `Usage: agentry-slack <command>
+const USAGE = `Usage: agentry-slack <command> [args]
 
 Commands:
-  verify-scopes    Verify SLACK_BOT_TOKEN has all required OAuth scopes.
-                   Required env: SLACK_BOT_TOKEN
+  verify-scopes
+      Verify SLACK_BOT_TOKEN has all required OAuth scopes.
+      Required env: SLACK_BOT_TOKEN
+
+  list-channels
+      List public + private channels the bot is a member of (with IDs).
+      Required env: SLACK_BOT_TOKEN
+
+  send-test-message --channel <id> [--text <msg>] [--thread-ts <ts>]
+      Post a message to a channel as the bot. For ops smoke testing only.
+      Required env: SLACK_BOT_TOKEN
 `;
 
 export interface RunSlackCliIo {
@@ -22,20 +32,52 @@ const DEFAULT_IO: RunSlackCliIo = {
   },
 };
 
+export type SlackWebClientFactory = (token: string) => WebClient;
+
+const DEFAULT_WEB_CLIENT_FACTORY: SlackWebClientFactory = (token) => new WebClient(token);
+
+export interface RunSlackCliOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly io?: RunSlackCliIo;
+  readonly fetchImpl?: typeof globalThis.fetch;
+  readonly webClientFactory?: SlackWebClientFactory;
+}
+
 export async function runSlackCli(
   argv: readonly string[],
-  env: NodeJS.ProcessEnv = process.env,
-  io: RunSlackCliIo = DEFAULT_IO,
-  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+  options: RunSlackCliOptions = {},
 ): Promise<number> {
+  const env = options.env ?? process.env;
+  const io = options.io ?? DEFAULT_IO;
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  const factory = options.webClientFactory ?? DEFAULT_WEB_CLIENT_FACTORY;
+
   const command = argv[0];
+  const rest = argv.slice(1);
 
   if (command === 'verify-scopes') {
     return verifyScopesCommand(env, io, fetchImpl);
   }
+  if (command === 'list-channels') {
+    return listChannelsCommand(env, io, factory);
+  }
+  if (command === 'send-test-message') {
+    return sendTestMessageCommand(rest, env, io, factory);
+  }
 
   io.err(USAGE);
   return 1;
+}
+
+// Returns the token, or null after writing the missing-token error to io.err.
+// Centralized so adding a fourth command doesn't reintroduce the guard.
+function requireBotToken(env: NodeJS.ProcessEnv, io: RunSlackCliIo): string | null {
+  const token = env.SLACK_BOT_TOKEN;
+  if (token === undefined || token.length === 0) {
+    io.err('SLACK_BOT_TOKEN must be set in the environment');
+    return null;
+  }
+  return token;
 }
 
 async function verifyScopesCommand(
@@ -43,11 +85,8 @@ async function verifyScopesCommand(
   io: RunSlackCliIo,
   fetchImpl: typeof globalThis.fetch,
 ): Promise<number> {
-  const token = env.SLACK_BOT_TOKEN;
-  if (token === undefined || token.length === 0) {
-    io.err('SLACK_BOT_TOKEN must be set in the environment');
-    return 1;
-  }
+  const token = requireBotToken(env, io);
+  if (token === null) return 1;
 
   try {
     const info = await verifySlackScopes(token, SLACK_REQUIRED_SCOPES, fetchImpl);
@@ -63,4 +102,102 @@ async function verifyScopesCommand(
     io.err(`verify-scopes failed: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
   }
+}
+
+interface SlackChannelSummary {
+  readonly id?: string;
+  readonly name?: string;
+  readonly is_member?: boolean;
+  readonly is_private?: boolean;
+}
+
+async function listChannelsCommand(
+  env: NodeJS.ProcessEnv,
+  io: RunSlackCliIo,
+  factory: SlackWebClientFactory,
+): Promise<number> {
+  const token = requireBotToken(env, io);
+  if (token === null) return 1;
+
+  const client = factory(token);
+  try {
+    // Single page, capped at 200. Bots are typically in <100 channels;
+    // pagination support will land if production usage hits the cap.
+    const res = await client.conversations.list({
+      types: 'public_channel,private_channel',
+      limit: 200,
+      exclude_archived: true,
+    });
+    if (!res.ok || !res.channels) {
+      io.err(`conversations.list failed: ${res.error ?? 'unknown'}`);
+      return 1;
+    }
+    const member = (res.channels as readonly SlackChannelSummary[]).filter(
+      (c) => c.is_member === true,
+    );
+    if (member.length === 0) {
+      io.out('No channels — invite the bot first via /invite @<bot> in the target channel');
+      return 0;
+    }
+    for (const c of member) {
+      const id = c.id ?? '';
+      const name = c.name ?? '';
+      const visibility = c.is_private === true ? 'private' : 'public';
+      io.out(`${id}\t${name}\t(${visibility})`);
+    }
+    return 0;
+  } catch (err) {
+    io.err(`list-channels failed: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+async function sendTestMessageCommand(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  io: RunSlackCliIo,
+  factory: SlackWebClientFactory,
+): Promise<number> {
+  const token = requireBotToken(env, io);
+  if (token === null) return 1;
+
+  const flags = parseFlags(args);
+  const channel = flags.get('channel');
+  if (channel === undefined || channel.length === 0) {
+    io.err('send-test-message requires --channel <id>');
+    return 1;
+  }
+  const text = flags.get('text') ?? 'agentry-slack send-test-message smoke';
+  const threadTs = flags.get('thread-ts');
+
+  const client = factory(token);
+  try {
+    const res = await client.chat.postMessage({
+      channel,
+      text,
+      ...(threadTs !== undefined && threadTs.length > 0 ? { thread_ts: threadTs } : {}),
+    });
+    if (!res.ok || !res.ts) {
+      io.err(`chat.postMessage failed: ${res.error ?? 'response missing ts'}`);
+      return 1;
+    }
+    io.out(`posted ts=${res.ts} channel=${channel}`);
+    return 0;
+  } catch (err) {
+    io.err(`send-test-message failed: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+}
+
+function parseFlags(argv: readonly string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (typeof a !== 'string' || !a.startsWith('--')) continue;
+    const next = argv[i + 1];
+    if (typeof next !== 'string') continue;
+    out.set(a.slice(2), next);
+    i++;
+  }
+  return out;
 }

--- a/packages/adapter-channel-slack/src/mcp/server.ts
+++ b/packages/adapter-channel-slack/src/mcp/server.ts
@@ -12,6 +12,11 @@ import {
   getChannelHistoryInputShape,
   SLACK_GET_CHANNEL_HISTORY_TOOL_NAME,
 } from './tools/get-channel-history.js';
+import {
+  getUserInfo,
+  getUserInfoInputShape,
+  SLACK_GET_USER_INFO_TOOL_NAME,
+} from './tools/get-user-info.js';
 
 const SERVER_VERSION = '0.0.0';
 
@@ -28,7 +33,7 @@ async function main(): Promise<void> {
     {
       capabilities: { tools: {} },
       instructions:
-        'Tools for reading Slack channel context. Bot-authored messages are preserved with bot_id intact so the agent can reason about content posted by other bots in the same channel.',
+        'Tools for reading Slack channel context. `slack_get_channel_history` returns recent messages with bot_id preserved (other bots distinguishable from humans). `slack_get_user_info` resolves a user ID to a display name so the agent can refer to humans by name in its replies.',
     },
   );
 
@@ -40,6 +45,16 @@ async function main(): Promise<void> {
       inputSchema: getChannelHistoryInputShape,
     },
     async (args) => getChannelHistory(client, args),
+  );
+
+  server.registerTool(
+    SLACK_GET_USER_INFO_TOOL_NAME,
+    {
+      description:
+        'Look up a Slack user by ID. Returns id, name, optional real_name / display_name, and is_bot. Use after `slack_get_channel_history` returns a `user` field that needs resolution to a human-readable name.',
+      inputSchema: getUserInfoInputShape,
+    },
+    async (args) => getUserInfo(client, args),
   );
 
   const transport = new StdioServerTransport();

--- a/packages/adapter-channel-slack/src/mcp/tools/get-channel-history.ts
+++ b/packages/adapter-channel-slack/src/mcp/tools/get-channel-history.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import type { WebClient } from '@slack/web-api';
 import { z } from 'zod';
+import { errorResult } from './tool-result.js';
 
 export const SLACK_GET_CHANNEL_HISTORY_TOOL_NAME = 'slack_get_channel_history';
 
@@ -81,12 +82,5 @@ function toHistoryMessage(m: {
     ...(m.username !== undefined ? { username: m.username } : {}),
     text: m.text ?? '',
     ...(m.thread_ts !== undefined ? { thread_ts: m.thread_ts } : {}),
-  };
-}
-
-function errorResult(message: string): CallToolResult {
-  return {
-    content: [{ type: 'text', text: message }],
-    isError: true,
   };
 }

--- a/packages/adapter-channel-slack/src/mcp/tools/get-user-info.test.ts
+++ b/packages/adapter-channel-slack/src/mcp/tools/get-user-info.test.ts
@@ -1,0 +1,117 @@
+import type { WebClient } from '@slack/web-api';
+import { describe, expect, it, vi } from 'vitest';
+import { getUserInfo } from './get-user-info.js';
+
+interface FakeUserResponse {
+  readonly ok: boolean;
+  readonly error?: string;
+  readonly user?: Record<string, unknown>;
+}
+
+function fakeClient(responses: {
+  info: (req: Record<string, unknown>) => Promise<FakeUserResponse>;
+}): WebClient {
+  return {
+    users: { info: vi.fn(responses.info) },
+  } as unknown as WebClient;
+}
+
+describe('getUserInfo', () => {
+  it('returns mapped user data with display_name preferred from profile', async () => {
+    const client = fakeClient({
+      info: async () => ({
+        ok: true,
+        user: {
+          id: 'U999',
+          name: 'nakhun',
+          real_name: 'Nakhun Song (top-level)',
+          is_bot: false,
+          tz: 'Asia/Seoul',
+          profile: {
+            display_name: 'nakhun',
+            real_name: 'Nakhun Song',
+          },
+        },
+      }),
+    });
+
+    const result = await getUserInfo(client, { user: 'U999' });
+
+    expect(result.isError).toBeUndefined();
+    const payload = JSON.parse(result.content[0].text) as {
+      user: Record<string, unknown>;
+    };
+    expect(payload.user).toEqual({
+      id: 'U999',
+      name: 'nakhun',
+      real_name: 'Nakhun Song',
+      display_name: 'nakhun',
+      is_bot: false,
+      tz: 'Asia/Seoul',
+    });
+  });
+
+  it('falls back to top-level real_name when profile.real_name is missing', async () => {
+    const client = fakeClient({
+      info: async () => ({
+        ok: true,
+        user: {
+          id: 'U001',
+          name: 'legacy-user',
+          real_name: 'Legacy Real',
+          is_bot: false,
+          profile: {},
+        },
+      }),
+    });
+
+    const result = await getUserInfo(client, { user: 'U001' });
+
+    const payload = JSON.parse(result.content[0].text) as { user: Record<string, unknown> };
+    expect(payload.user.real_name).toBe('Legacy Real');
+    expect(payload.user.display_name).toBeUndefined();
+  });
+
+  it('flags bots via is_bot=true', async () => {
+    const client = fakeClient({
+      info: async () => ({
+        ok: true,
+        user: {
+          id: 'U-BOT',
+          name: 'workflow-bot',
+          is_bot: true,
+          profile: { display_name: 'workflow-bot' },
+        },
+      }),
+    });
+
+    const result = await getUserInfo(client, { user: 'U-BOT' });
+
+    const payload = JSON.parse(result.content[0].text) as { user: { is_bot: boolean } };
+    expect(payload.user.is_bot).toBe(true);
+  });
+
+  it('returns isError=true when Slack responds with !ok', async () => {
+    const client = fakeClient({
+      info: async () => ({ ok: false, error: 'user_not_found' }),
+    });
+
+    const result = await getUserInfo(client, { user: 'U-MISSING' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('user_not_found');
+  });
+
+  it('returns isError=true when the underlying call throws', async () => {
+    const client = fakeClient({
+      info: async () => {
+        throw new Error('network down');
+      },
+    });
+
+    const result = await getUserInfo(client, { user: 'U-X' });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('network down');
+  });
+});

--- a/packages/adapter-channel-slack/src/mcp/tools/get-user-info.ts
+++ b/packages/adapter-channel-slack/src/mcp/tools/get-user-info.ts
@@ -1,0 +1,72 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import type { WebClient } from '@slack/web-api';
+import { z } from 'zod';
+import { errorResult } from './tool-result.js';
+
+export const SLACK_GET_USER_INFO_TOOL_NAME = 'slack_get_user_info';
+
+export const getUserInfoInputShape = {
+  user: z
+    .string()
+    .min(1)
+    .describe(
+      'Slack user ID (e.g. U0123456). Use the `user` field from `slack_get_channel_history` results.',
+    ),
+};
+
+const InputSchema = z.object(getUserInfoInputShape);
+export type GetUserInfoInput = z.infer<typeof InputSchema>;
+
+export interface SlackUserInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly real_name?: string;
+  readonly display_name?: string;
+  readonly is_bot: boolean;
+  readonly tz?: string;
+}
+
+export async function getUserInfo(
+  client: WebClient,
+  args: GetUserInfoInput,
+): Promise<CallToolResult> {
+  try {
+    const res = await client.users.info({ user: args.user });
+    if (!res.ok || !res.user) {
+      return errorResult(`Slack API error: ${res.error ?? 'unknown'}`);
+    }
+    const user = toUserInfo(res.user);
+    return {
+      content: [{ type: 'text', text: JSON.stringify({ user }) }],
+    };
+  } catch (err) {
+    return errorResult(
+      `Slack API call failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+interface RawSlackUser {
+  readonly id?: string;
+  readonly name?: string;
+  readonly real_name?: string;
+  readonly is_bot?: boolean;
+  readonly tz?: string;
+  readonly profile?: {
+    readonly display_name?: string;
+    readonly real_name?: string;
+  };
+}
+
+function toUserInfo(u: RawSlackUser): SlackUserInfo {
+  const displayName = u.profile?.display_name;
+  const realName = u.profile?.real_name ?? u.real_name;
+  return {
+    id: u.id ?? '',
+    name: u.name ?? '',
+    ...(realName !== undefined && realName.length > 0 ? { real_name: realName } : {}),
+    ...(displayName !== undefined && displayName.length > 0 ? { display_name: displayName } : {}),
+    is_bot: u.is_bot ?? false,
+    ...(u.tz !== undefined ? { tz: u.tz } : {}),
+  };
+}

--- a/packages/adapter-channel-slack/src/mcp/tools/tool-result.ts
+++ b/packages/adapter-channel-slack/src/mcp/tools/tool-result.ts
@@ -1,0 +1,8 @@
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+export function errorResult(message: string): CallToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}

--- a/packages/adapter-channel-slack/src/slack-inbound-channel.ts
+++ b/packages/adapter-channel-slack/src/slack-inbound-channel.ts
@@ -8,13 +8,18 @@ import {
 import type { SlackHistoryBackfiller } from './slack-history-backfiller.js';
 import { verifySlackScopes } from './slack-scope-verifier.js';
 
-// Channel mention + thread backfill scopes. Reading prior thread messages
-// requires `*:history` per channel type the bot is invited to.
+// Channel mention + thread backfill + user/channel lookup scopes. Reading
+// prior thread messages requires `*:history` per channel type the bot is
+// invited to. `users:read` powers `slack_get_user_info` (display-name
+// resolution); `*:read` powers `agentry-slack list-channels`.
 export const SLACK_REQUIRED_SCOPES: readonly string[] = [
   'app_mentions:read',
   'chat:write',
   'channels:history',
   'groups:history',
+  'channels:read',
+  'groups:read',
+  'users:read',
 ];
 
 const DEFAULT_TENANT: TenantId = 'default';

--- a/seed/agent-workdir/CLAUDE.md
+++ b/seed/agent-workdir/CLAUDE.md
@@ -33,14 +33,22 @@ deploy bot say about the last release".
 ### `slack_get_user_info`
 
 Resolve a Slack user ID (e.g. `U0123456`) to a display name. Returns `id`,
-`name`, optional `real_name` / `display_name`, and `is_bot`. Use this after
-`slack_get_channel_history` so your reply refers to people by name rather
-than by raw ID.
+`name`, optional `real_name` / `display_name`, and `is_bot`.
 
-Pair the two tools: get history → collect distinct `user` IDs → call
-`slack_get_user_info` for each → write the summary using human-readable
-names. Do not call it for `bot_id` values; those are bot identifiers, not
-user IDs.
+**Always resolve `user:` IDs before replying.** A user-facing reply must
+not contain raw `U...` IDs — Slack users do not recognize them and the
+output looks like a leaked internal token. Workflow:
+
+1. Call `slack_get_channel_history` to read recent messages.
+2. Collect every distinct `user:` value in the messages you plan to cite.
+3. Call `slack_get_user_info` once per distinct ID (these calls are
+   independent — Claude Code may parallelize them).
+4. Write the summary using `display_name` (fallback `real_name`, then
+   `name`) instead of the raw ID.
+
+Do not call it for `bot_id` values — those are bot identifiers, not user
+IDs, and the API will return `user_not_found`. Cite bots by their
+`username` field from `slack_get_channel_history` instead.
 
 #### Resolving "this channel"
 

--- a/seed/agent-workdir/CLAUDE.md
+++ b/seed/agent-workdir/CLAUDE.md
@@ -30,6 +30,18 @@ Use this tool when the user's question references prior context the agent
 hasn't seen — for example, "summarize today's QA reports" or "what did the
 deploy bot say about the last release".
 
+### `slack_get_user_info`
+
+Resolve a Slack user ID (e.g. `U0123456`) to a display name. Returns `id`,
+`name`, optional `real_name` / `display_name`, and `is_bot`. Use this after
+`slack_get_channel_history` so your reply refers to people by name rather
+than by raw ID.
+
+Pair the two tools: get history → collect distinct `user` IDs → call
+`slack_get_user_info` for each → write the summary using human-readable
+names. Do not call it for `bot_id` values; those are bot identifiers, not
+user IDs.
+
 #### Resolving "this channel"
 
 The user prompt is prefixed with a `[Channel context]` block (header is


### PR DESCRIPTION
## Summary

PR2 of #26. Lands the second batch of Slack agent-callable tools and operator CLI commands.

- **`slack_get_user_info(user)`** MCP tool — `users.info` wrapper. Pairs with `slack_get_channel_history` so the agent resolves raw `U...` IDs to display names before replying.
- **`agentry-slack list-channels`** + **`send-test-message --channel <id> [--text <msg>] [--thread-ts <ts>]`** — operator-facing debug commands. `list-channels` returns only channels the bot is a member of; `send-test-message` lets ops verify the post path (with optional thread reply) without going through Slack mentions.
- Shared `errorResult` helper in `mcp/tools/tool-result.ts` removes the duplicate scaffolding both MCP tools previously carried. `runSlackCli` switched to an options-object signature; per-command `SLACK_BOT_TOKEN` guard collapsed into `requireBotToken`.

## ⚠️ Deployment action required

This PR adds three new entries to `SLACK_REQUIRED_SCOPES`:

- `users:read` (powers `slack_get_user_info`)
- `channels:read` + `groups:read` (powers `agentry-slack list-channels`)

**Existing deployments must reinstall the Slack app and refresh `SLACK_BOT_TOKEN`** before the next restart — otherwise `verifySlackScopes` throws at boot. The smoke recipe's app manifest is updated with the new scope set.

## What's NOT in this PR

- **`slack_search_messages` deferred.** Slack `search.messages` requires a USER token (`xoxp-`) rather than a bot token. That's a credential-class change (separate OAuth flow + `SLACK_USER_TOKEN` plumbing + dual-token `verify-scopes`), not a scope addition. In-channel filtering is approximated via `slack_get_channel_history` for now; new driver = new followup.
- SIGTERM tempfile cleanup in `ClaudeCliAgentRunner` (cross-cutting #26 followup).
- `node --env-file` shell-export fail-fast guard in apps/server (the smoke recipe now has the `unset` workaround as Step 8 prefix).

## Verification

### Unit / lint / build
- `pnpm typecheck` clean
- `pnpm lint` clean (0 errors; 6 pre-existing infos on unchanged files)
- `pnpm test` clean (204 passed, 26 skipped — +14 new)
- `pnpm depcheck` clean (no new layer violations)
- `pnpm build` clean; `mcp/server.test.ts` built-smoke (stdout-purity guard) passes

### Live end-to-end against a real workspace
Booted apps/server with reinstalled bot token + new scopes. Sent the killer-use-case prompt that PR2 exists for:

> @agentry-smoke 이 채널에서 누가 무슨 얘기 했는지 사람 이름으로 정리해줘

Agent reply (DB-persisted, ~63s after mention):

> 이 채널의 메시지를 사람 이름 기준으로 정리했어요. (참여자: **송낙훈** — 사람 / NakBot, agentry-smoke — 봇)
>
> ## 송낙훈 (nakhun.song)
> 사실상 모든 사람 발화는 송낙훈 본인. 시간대별로 묶으면: ...

That confirms end-to-end: `slack_get_channel_history` → distinct `user:` IDs → `slack_get_user_info(U044K34GBLP)` → display name `송낙훈` (`nakhun.song`) → no raw `U...` IDs in user-facing output. Other bots cited by `username` (`NakBot`, `agentry-smoke`), not raw `B...` bot IDs. Both turns persisted in `turns`.

The seed `CLAUDE.md` imperative ("Always resolve `user:` IDs before replying. Do not include raw `U...` IDs in user-facing replies.") locks this behavior in.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors; 6 pre-existing infos)
- [x] `pnpm test` clean (204 passed, 26 skipped)
- [x] `pnpm depcheck` clean
- [x] `pnpm build` clean
- [x] Live Slack workspace e2e: agent chains `slack_get_channel_history` + `slack_get_user_info`, reply uses display names, both turns persisted in pgvector

Refs #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)