### PR TITLE
feat(runner,server): SIGTERM tempfile cleanup + .env shadow fail-fast (#26 cross-cutting)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc -b",
     "start": "node dist/main.js",
-    "dev": "tsx watch src/main.ts"
+    "dev": "tsx watch src/main.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@agentry/adapter-channel-slack": "workspace:*",

--- a/apps/server/src/env-shadow-check.test.ts
+++ b/apps/server/src/env-shadow-check.test.ts
@@ -1,0 +1,105 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { detectEnvShadowConflicts, formatEnvShadowError } from './env-shadow-check.js';
+
+describe('detectEnvShadowConflicts', () => {
+  let scratchDir: string;
+  let envPath: string;
+
+  beforeEach(() => {
+    scratchDir = mkdtempSync(join(tmpdir(), 'env-shadow-test-'));
+    envPath = join(scratchDir, '.env');
+  });
+
+  afterEach(() => {
+    rmSync(scratchDir, { recursive: true, force: true });
+  });
+
+  it('returns empty when the file does not exist', () => {
+    const result = detectEnvShadowConflicts(join(scratchDir, 'missing.env'), {
+      SLACK_BOT_TOKEN: 'xoxb-shell',
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty when shell value matches .env value', () => {
+    writeFileSync(envPath, 'SLACK_BOT_TOKEN=xoxb-same\n');
+    const result = detectEnvShadowConflicts(envPath, { SLACK_BOT_TOKEN: 'xoxb-same' });
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty when shell does not have the key', () => {
+    writeFileSync(envPath, 'SLACK_BOT_TOKEN=xoxb-only-in-env\n');
+    const result = detectEnvShadowConflicts(envPath, {});
+    expect(result).toEqual([]);
+  });
+
+  it('reports a conflict when shell shadows .env with a different value', () => {
+    writeFileSync(envPath, 'SLACK_BOT_TOKEN=xoxb-from-env\n');
+    const result = detectEnvShadowConflicts(envPath, { SLACK_BOT_TOKEN: 'xoxb-from-shell' });
+    expect(result).toEqual([{ key: 'SLACK_BOT_TOKEN' }]);
+  });
+
+  it('skips comments and blank lines', () => {
+    writeFileSync(
+      envPath,
+      ['# comment line', '', '   ', 'SLACK_BOT_TOKEN=xoxb-from-env', '# another'].join('\n'),
+    );
+    const result = detectEnvShadowConflicts(envPath, { SLACK_BOT_TOKEN: 'xoxb-shell' });
+    expect(result).toEqual([{ key: 'SLACK_BOT_TOKEN' }]);
+  });
+
+  it('strips matching outer double quotes from .env value', () => {
+    writeFileSync(envPath, 'POSTGRES_URL="postgres://a:b@h/d"\n');
+    const same = detectEnvShadowConflicts(envPath, { POSTGRES_URL: 'postgres://a:b@h/d' });
+    expect(same).toEqual([]);
+    const diff = detectEnvShadowConflicts(envPath, { POSTGRES_URL: 'other' });
+    expect(diff).toEqual([{ key: 'POSTGRES_URL' }]);
+  });
+
+  it('strips matching outer single quotes from .env value', () => {
+    writeFileSync(envPath, "VOYAGE_API_KEY='pa-secret'\n");
+    const result = detectEnvShadowConflicts(envPath, { VOYAGE_API_KEY: 'pa-secret' });
+    expect(result).toEqual([]);
+  });
+
+  it('preserves `=` characters in .env values', () => {
+    writeFileSync(envPath, 'POSTGRES_URL=postgres://u:p=secret@h/d\n');
+    const result = detectEnvShadowConflicts(envPath, {
+      POSTGRES_URL: 'postgres://u:p=secret@h/d',
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('honors `export KEY=value` syntax', () => {
+    writeFileSync(envPath, 'export SLACK_BOT_TOKEN=xoxb-from-env\n');
+    const result = detectEnvShadowConflicts(envPath, { SLACK_BOT_TOKEN: 'xoxb-from-shell' });
+    expect(result).toEqual([{ key: 'SLACK_BOT_TOKEN' }]);
+  });
+
+  it('reports multiple conflicts in iteration order of .env', () => {
+    writeFileSync(envPath, ['SLACK_BOT_TOKEN=a', 'POSTGRES_URL=b', 'VOYAGE_API_KEY=c'].join('\n'));
+    const result = detectEnvShadowConflicts(envPath, {
+      SLACK_BOT_TOKEN: 'shell-a',
+      POSTGRES_URL: 'b',
+      VOYAGE_API_KEY: 'shell-c',
+    });
+    expect(result).toEqual([{ key: 'SLACK_BOT_TOKEN' }, { key: 'VOYAGE_API_KEY' }]);
+  });
+});
+
+describe('formatEnvShadowError', () => {
+  it('lists keys without leaking values', () => {
+    const msg = formatEnvShadowError('.env', [{ key: 'SLACK_BOT_TOKEN' }, { key: 'POSTGRES_URL' }]);
+    expect(msg).toContain('2 key(s)');
+    expect(msg).toContain('.env');
+    expect(msg).toContain('SLACK_BOT_TOKEN');
+    expect(msg).toContain('POSTGRES_URL');
+    // Sanity: any actual secret-shaped value would not appear here because
+    // the function only takes the conflict list, but assert anyway to lock
+    // in the no-value-leak guarantee.
+    expect(msg).not.toMatch(/xoxb-/);
+  });
+});

--- a/apps/server/src/env-shadow-check.ts
+++ b/apps/server/src/env-shadow-check.ts
@@ -1,0 +1,67 @@
+// Detects when shell-exported environment variables shadow values defined in
+// the user's .env file. Node's `--env-file=.env` does NOT override variables
+// already exported in the parent shell, so a stale shell export silently
+// causes the .env value to be ignored. apps/server fails fast on conflict so
+// the user sees the issue at boot rather than chasing a wrong-token symptom
+// across deployments.
+//
+// The parser is intentionally minimal — see `EnvShadowParserNote` in the
+// thrown error message. Match the 95% case (KEY=VALUE, comments, single /
+// double-quoted values, optional `export ` prefix). Anything fancier
+// (multi-line quoted values, escape sequences) is beyond scope; the goal is
+// to catch the obvious shadow trap, not to perfectly mirror Node's parser.
+
+import { existsSync, readFileSync } from 'node:fs';
+
+export interface EnvShadowConflict {
+  readonly key: string;
+}
+
+export function detectEnvShadowConflicts(
+  envFilePath: string,
+  processEnv: NodeJS.ProcessEnv,
+): readonly EnvShadowConflict[] {
+  if (!existsSync(envFilePath)) return [];
+  const text = readFileSync(envFilePath, 'utf8');
+  const conflicts: EnvShadowConflict[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith('#')) continue;
+    const stripped = line.startsWith('export ') ? line.slice('export '.length).trim() : line;
+    const eqIdx = stripped.indexOf('=');
+    if (eqIdx <= 0) continue;
+    const key = stripped.slice(0, eqIdx).trim();
+    if (key.length === 0) continue;
+    const value = stripQuotes(stripped.slice(eqIdx + 1));
+    const shellValue = processEnv[key];
+    if (shellValue === undefined) continue;
+    if (shellValue !== value) {
+      conflicts.push({ key });
+    }
+  }
+  return conflicts;
+}
+
+function stripQuotes(value: string): string {
+  if (value.length < 2) return value;
+  const first = value[0];
+  const last = value[value.length - 1];
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+export function formatEnvShadowError(
+  envFilePath: string,
+  conflicts: readonly EnvShadowConflict[],
+): string {
+  const keys = conflicts.map((c) => `  - ${c.key}`).join('\n');
+  return [
+    `env shadow detected: ${conflicts.length} key(s) differ between shell exports and ${envFilePath}.`,
+    'Node `--env-file` does NOT override shell-exported values, so the .env definition is being silently ignored.',
+    'Either `unset` the shell exports or align them with .env. Affected keys:',
+    keys,
+    'This check uses a minimal .env parser; complex syntax (multi-line strings, escape sequences) may be missed.',
+  ].join('\n');
+}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -10,6 +10,7 @@ import { AgentryConfigSchema, compose, loadSecrets } from '@agentry/runtime';
 import { serve } from '@hono/node-server';
 import { WebClient } from '@slack/web-api';
 import { Hono } from 'hono';
+import { detectEnvShadowConflicts, formatEnvShadowError } from './env-shadow-check.js';
 
 function parsePort(raw: string, label: string): number {
   const port = Number.parseInt(raw, 10);
@@ -20,6 +21,16 @@ function parsePort(raw: string, label: string): number {
 }
 
 async function main(): Promise<void> {
+  // Run BEFORE loadSecrets so the user sees the env-shadow error message
+  // (which points at the root cause) instead of a downstream Slack/DB
+  // auth-failure that hides it. Skipped silently when the .env file is
+  // absent (e.g., production deployments injecting env vars directly).
+  const envFilePath = process.env.AGENTRY_ENV_FILE ?? '.env';
+  const conflicts = detectEnvShadowConflicts(envFilePath, process.env);
+  if (conflicts.length > 0) {
+    throw new Error(formatEnvShadowError(envFilePath, conflicts));
+  }
+
   const secrets = loadSecrets();
   const config = AgentryConfigSchema.parse({
     agentWorkdir: process.env.AGENT_WORKDIR ?? './seed/agent-workdir',

--- a/docs/recipes/smoke-test.md
+++ b/docs/recipes/smoke-test.md
@@ -143,7 +143,10 @@ pnpm typecheck && pnpm lint && pnpm test && pnpm depcheck
 ```bash
 # Node `--env-file` does NOT override variables already exported in the
 # parent shell. If a previous session exported these, .env is silently
-# shadowed and the server boots with stale values.
+# shadowed. apps/server now fail-fasts with an `env shadow detected`
+# error at boot when this happens — this `unset` keeps the shell clean
+# so you avoid hitting that path. Override the path with
+# `AGENTRY_ENV_FILE=.env.production` if your file is not `.env`.
 unset SLACK_BOT_TOKEN SLACK_SIGNING_SECRET POSTGRES_URL VOYAGE_API_KEY
 
 node --env-file=.env apps/server/dist/main.js

--- a/packages/adapter-runner-claude-cli/src/claude-cli-runner.test.ts
+++ b/packages/adapter-runner-claude-cli/src/claude-cli-runner.test.ts
@@ -1,12 +1,12 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import type { AgentEvent } from '@agentry/core';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { ClaudeCliAgentRunner } from './claude-cli-runner.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ClaudeCliAgentRunner, cleanupMcpConfig } from './claude-cli-runner.js';
 
 class FakeChildProcess extends EventEmitter {
   stdin = new PassThrough();
@@ -255,6 +255,63 @@ describe('ClaudeCliAgentRunner', () => {
       await events;
 
       expect(captured).not.toContain('--mcp-config');
+    });
+  });
+
+  describe('cleanupMcpConfig', () => {
+    let scratchDir: string;
+
+    beforeEach(() => {
+      scratchDir = mkdtempSync(join(tmpdir(), 'mcp-cleanup-test-'));
+    });
+
+    afterEach(() => {
+      rmSync(scratchDir, { recursive: true, force: true });
+    });
+
+    it('unlinks the file when present', () => {
+      const path = join(scratchDir, 'present.json');
+      writeFileSync(path, '{}');
+      expect(existsSync(path)).toBe(true);
+      cleanupMcpConfig(path);
+      expect(existsSync(path)).toBe(false);
+    });
+
+    it('is idempotent when the file is already gone', () => {
+      const path = join(scratchDir, 'missing.json');
+      expect(existsSync(path)).toBe(false);
+      expect(() => cleanupMcpConfig(path)).not.toThrow();
+    });
+  });
+
+  describe('cleanup registration on signals', () => {
+    it('registers exit, SIGINT, and SIGTERM listeners when the runner owns the tempfile path', () => {
+      const onceSpy = vi.spyOn(process, 'once');
+      const fake = new FakeChildProcess();
+      // mcpConfigPath omitted ⇒ runner generates its own path AND registers
+      // cleanup. We assert against process.once instead of the actual signal
+      // path so the test does not pollute os.tmpdir() across runs.
+      try {
+        new ClaudeCliAgentRunner({
+          spawn: () => asChildProcess(fake),
+          mcpServers: [{ name: 'agentry-x', command: '/usr/bin/node', args: ['/abs/x.js'] }],
+        });
+        const registeredEvents = onceSpy.mock.calls.map((c) => c[0]);
+        expect(registeredEvents).toContain('exit');
+        expect(registeredEvents).toContain('SIGINT');
+        expect(registeredEvents).toContain('SIGTERM');
+      } finally {
+        // Drive the cleanup synchronously so the auto-generated tempfile is
+        // unlinked immediately instead of relying on `exit` at test-runner
+        // shutdown.
+        for (const [event, handler] of onceSpy.mock.calls) {
+          if (event === 'exit' && typeof handler === 'function') {
+            handler();
+            break;
+          }
+        }
+        onceSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/adapter-runner-claude-cli/src/claude-cli-runner.ts
+++ b/packages/adapter-runner-claude-cli/src/claude-cli-runner.ts
@@ -180,12 +180,26 @@ function writeMcpConfigJson(filePath: string, servers: readonly McpServerConfig[
   writeFileSync(filePath, JSON.stringify({ mcpServers: entries }), { mode: 0o600 });
 }
 
+// Exported for unit tests that exercise the unlink semantics directly.
+export function cleanupMcpConfig(filePath: string): void {
+  try {
+    unlinkSync(filePath);
+  } catch {
+    // best effort — file may have been removed already
+  }
+}
+
 function registerMcpConfigCleanup(filePath: string): void {
-  process.once('exit', () => {
-    try {
-      unlinkSync(filePath);
-    } catch {
-      // best effort — file may have been removed already
-    }
-  });
+  const cleanup = () => cleanupMcpConfig(filePath);
+  // `exit` covers natural termination (event loop drained, process.exit()).
+  // SIGINT/SIGTERM are required because Node does NOT fire 'exit' when the
+  // process is killed by an unhandled signal. Note: registering ANY listener
+  // for SIGINT/SIGTERM suppresses Node's default-fatal behavior. apps/server
+  // already registers its own graceful-shutdown handlers, so default-action
+  // suppression is already in effect there. Embedders that want default
+  // signal-fatal behavior must drive their own process.exit() from a
+  // higher-priority handler — this listener does NOT re-raise.
+  process.once('exit', cleanup);
+  process.once('SIGINT', cleanup);
+  process.once('SIGTERM', cleanup);
 }


### PR DESCRIPTION
## Summary

Two #26 cross-cutting followups, both surfaced empirically during PR1's e2e and tracked in the issue body since then.

### SIGTERM tempfile cleanup (`ClaudeCliAgentRunner`)

`process.once('exit')` does not fire on signal-kill — PR1's e2e left 7 stale `agentry-mcp-${pid}-*.json` tempfiles in `os.tmpdir()` after `kill <server-pid>`. Cleanup is now registered on `exit`, `SIGINT`, AND `SIGTERM`, all calling the same idempotent `unlinkSync` (caught). The new `cleanupMcpConfig` helper is exported for unit tests.

Comment in source explains the signal-semantics gotcha: registering listeners suppresses Node's default-fatal behavior, so embedders that rely on default signal-fatal must drive their own `process.exit()` from a higher-priority handler. apps/server already does this via its own graceful-shutdown handlers, so behavior is unchanged for the only current consumer.

### `.env` shadow fail-fast (`apps/server`)

Node `--env-file=.env` does NOT override variables already exported in the parent shell. PR1 e2e silently booted with a stale `SLACK_BOT_TOKEN` because the shell's exported value shadowed the rotated `.env` value, and the failure mode (`channel_not_found`) pointed at the bot's channel membership rather than the actual cause.

`apps/server/src/env-shadow-check.ts` introduces:

- `detectEnvShadowConflicts(envFilePath, processEnv): readonly EnvShadowConflict[]` — reads `.env`, parses minimal `KEY=VALUE` (with `# comment`, blank lines, optional `export `, single/double-quoted values), and returns keys whose `processEnv` value differs.
- `formatEnvShadowError(envFilePath, conflicts): string` — formats a clear error listing **only keys** (no values) to prevent token-shape leaks.

Wired into `main()` BEFORE `loadSecrets` so the user sees the root-cause error instead of a downstream auth failure. Path overridable via `AGENTRY_ENV_FILE` for non-`.env` deployments. Skipped silently when no file exists (production env-injection path).

The parser is intentionally minimal — the error message says so, and the `unset` workaround in the smoke recipe remains the recommended pre-flight.

## Verification

### Unit / lint / build
- `pnpm typecheck` clean
- `pnpm lint` clean (0 errors; 6 pre-existing infos on unchanged files)
- `pnpm test` clean (218 passed, 26 skipped — +14 new across cleanup, signal registration, env-shadow detection, error formatting)
- `pnpm depcheck` clean
- `pnpm build` clean

### Manual smoke (per advisor request — listener-registration assertions are not the same as signal-fire integration)

**SIGTERM cleanup**
1. Boot apps/server with new build
2. `ls $TMPDIR/agentry-mcp-${pid}-*.json` → file exists
3. `kill -TERM <pid>`
4. `ls $TMPDIR/agentry-mcp-${pid}-*.json` → `No such file or directory` ✅

apps/server's existing graceful shutdown also fires; both handlers run, runner's cleanup is the synchronous unlink.

**env shadow fail-fast**
```
$ SLACK_BOT_TOKEN=xoxb-shadow-stub node --env-file=.env apps/server/dist/main.js
Fatal startup error: Error: env shadow detected: 1 key(s) differ between shell exports and .env.
Node `--env-file` does NOT override shell-exported values, so the .env definition is being silently ignored.
Either `unset` the shell exports or align them with .env. Affected keys:
  - SLACK_BOT_TOKEN
This check uses a minimal .env parser; complex syntax (multi-line strings, escape sequences) may be missed.
```

Fires before any Slack/DB call.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors; 6 pre-existing infos)
- [x] `pnpm test` clean (218 passed, 26 skipped)
- [x] `pnpm depcheck` clean
- [x] `pnpm build` clean
- [x] Live SIGTERM cleanup integration check — tempfile unlinked on signal-kill
- [x] Live env-shadow fail-fast check — fails at boot with clear message before downstream calls

Refs #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)