### PR TITLE
feat(core,pgvector,testing,slack): SessionStore.findByRef + backfiller hot-path short-circuit (#64)

### DIFF
--- a/packages/adapter-channel-slack/src/slack-history-backfiller.test.ts
+++ b/packages/adapter-channel-slack/src/slack-history-backfiller.test.ts
@@ -69,19 +69,33 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 
 interface FakeSessionStore extends SessionStore {
   readonly findOrCreateMock: ReturnType<typeof vi.fn>;
+  readonly findByRefMock: ReturnType<typeof vi.fn>;
   readonly setMetadataMock: ReturnType<typeof vi.fn>;
 }
 
-function makeSessionStore(initial: Session = makeSession()): FakeSessionStore {
-  let current = initial;
-  const findOrCreateMock = vi.fn(async () => current);
+interface MakeSessionStoreOptions {
+  // null models the "no session exists yet" cold path; findByRef returns
+  // null and the backfiller falls back to findOrCreate.
+  readonly initial?: Session | null;
+}
+
+function makeSessionStore(options: MakeSessionStoreOptions = {}): FakeSessionStore {
+  let current: Session | null = options.initial === undefined ? makeSession() : options.initial;
+  const findByRefMock = vi.fn(async () => current);
+  const findOrCreateMock = vi.fn(async () => {
+    if (current === null) current = makeSession();
+    return current;
+  });
   const setMetadataMock = vi.fn(
     async (_id: SessionId, patch: Readonly<Record<string, unknown>>) => {
-      current = { ...current, metadata: { ...current.metadata, ...patch } };
+      if (current !== null) {
+        current = { ...current, metadata: { ...current.metadata, ...patch } };
+      }
     },
   );
   return {
     findOrCreate: findOrCreateMock as SessionStore['findOrCreate'],
+    findByRef: findByRefMock as SessionStore['findByRef'],
     setMetadata: setMetadataMock as SessionStore['setMetadata'],
     recordTurn: vi.fn(async (_id: SessionId, _t: TurnInput): Promise<Turn> => {
       throw new Error('not used');
@@ -90,6 +104,7 @@ function makeSessionStore(initial: Session = makeSession()): FakeSessionStore {
     updateStatus: vi.fn(async (_id: SessionId, _s: SessionStatus) => {}),
     listSessionsForDistillation: vi.fn(async (_c: DistillationCriteria) => []),
     findOrCreateMock,
+    findByRefMock,
     setMetadataMock,
   };
 }
@@ -123,10 +138,10 @@ const liveEvent: IncomingEvent = {
 };
 
 describe('SlackHistoryBackfiller', () => {
-  it('returns [] without calling Slack when session is already backfilled', async () => {
-    const store = makeSessionStore(
-      makeSession({ metadata: { [SLACK_BACKFILLED_METADATA_KEY]: true } }),
-    );
+  it('returns [] without calling Slack OR findOrCreate when session is already backfilled (#64)', async () => {
+    const store = makeSessionStore({
+      initial: makeSession({ metadata: { [SLACK_BACKFILLED_METADATA_KEY]: true } }),
+    });
     const repliesFn = vi.fn();
     const webClient = makeWebClient(repliesFn);
     const backfiller = new SlackHistoryBackfiller({
@@ -140,10 +155,48 @@ describe('SlackHistoryBackfiller', () => {
     expect(result).toEqual([]);
     expect(repliesFn).not.toHaveBeenCalled();
     expect(store.setMetadataMock).not.toHaveBeenCalled();
+    // The whole point of #64: the per-mention UPSERT is gone on the hot path.
+    expect(store.findOrCreateMock).not.toHaveBeenCalled();
+    expect(store.findByRefMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips findOrCreate when an existing-but-not-yet-backfilled session is returned by findByRef', async () => {
+    const store = makeSessionStore({
+      initial: makeSession({ metadata: {} }),
+    });
+    const backfiller = new SlackHistoryBackfiller({
+      webClient: makeWebClient(async () => ({ ok: true, messages: [] })),
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    await backfiller.backfillIfNeeded(liveEvent, 'default');
+
+    expect(store.findByRefMock).toHaveBeenCalledTimes(1);
+    // Existing session reused — no UPSERT needed.
+    expect(store.findOrCreateMock).not.toHaveBeenCalled();
+    // Backfill marker still gets persisted on the existing session id.
+    expect(store.setMetadataMock).toHaveBeenCalledWith('sess-1', {
+      [SLACK_BACKFILLED_METADATA_KEY]: true,
+    });
+  });
+
+  it('falls back to findOrCreate when no session exists yet (cold path, first ever touch)', async () => {
+    const store = makeSessionStore({ initial: null });
+    const backfiller = new SlackHistoryBackfiller({
+      webClient: makeWebClient(async () => ({ ok: true, messages: [] })),
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    await backfiller.backfillIfNeeded(liveEvent, 'default');
+
+    expect(store.findByRefMock).toHaveBeenCalledTimes(1);
+    expect(store.findOrCreateMock).toHaveBeenCalledTimes(1);
   });
 
   it('maps prior thread messages to synthetic IncomingEvents in chronological order', async () => {
-    const store = makeSessionStore();
+    const store = makeSessionStore({});
     const repliesFn = vi.fn(async () => ({
       ok: true,
       messages: [
@@ -182,7 +235,7 @@ describe('SlackHistoryBackfiller', () => {
   });
 
   it('excludes bot_id messages so bot replies are not recorded as user turns', async () => {
-    const store = makeSessionStore();
+    const store = makeSessionStore({});
     const repliesFn = vi.fn(async () => ({
       ok: true,
       messages: [
@@ -203,7 +256,7 @@ describe('SlackHistoryBackfiller', () => {
   });
 
   it('marks the session backfilled after a successful first run', async () => {
-    const store = makeSessionStore();
+    const store = makeSessionStore({});
     const backfiller = new SlackHistoryBackfiller({
       webClient: makeWebClient(async () => ({ ok: true, messages: [] })),
       sessionStore: store,
@@ -218,7 +271,7 @@ describe('SlackHistoryBackfiller', () => {
   });
 
   it('throws SlackHistoryBackfillError when conversations.replies returns ok: false', async () => {
-    const store = makeSessionStore();
+    const store = makeSessionStore({});
     const backfiller = new SlackHistoryBackfiller({
       webClient: makeWebClient(async () => ({ ok: false, error: 'channel_not_found' })),
       sessionStore: store,
@@ -232,7 +285,7 @@ describe('SlackHistoryBackfiller', () => {
   });
 
   it('collapses concurrent first-touch calls into a single Slack API request', async () => {
-    const store = makeSessionStore();
+    const store = makeSessionStore({});
     let resolve!: (value: ConversationsRepliesResult) => void;
     const inflight = new Promise<ConversationsRepliesResult>((r) => {
       resolve = r;
@@ -258,7 +311,7 @@ describe('SlackHistoryBackfiller', () => {
   });
 
   it('does not poison the lock when a backfill throws — next call retries', async () => {
-    const store = makeSessionStore();
+    const store = makeSessionStore({});
     let calls = 0;
     const repliesFn = vi.fn(async () => {
       calls += 1;

--- a/packages/adapter-channel-slack/src/slack-history-backfiller.ts
+++ b/packages/adapter-channel-slack/src/slack-history-backfiller.ts
@@ -73,12 +73,25 @@ export class SlackHistoryBackfiller {
     tenant: TenantId,
     ref: ChannelNativeRef,
   ): Promise<readonly IncomingEvent[]> {
-    const session = await this.opts.sessionStore.findOrCreate(
+    // Hot-path short-circuit: if the session already exists AND is
+    // backfilled, skip the UPSERT and the Slack API call entirely. The
+    // read-only `findByRef` keeps the already-backfilled mention path off
+    // the per-mention findOrCreate roundtrip (#64).
+    const existing = await this.opts.sessionStore.findByRef(
       this.opts.sessionPolicy.channelKind,
       ref,
       tenant,
     );
-    if (session.metadata[SLACK_BACKFILLED_METADATA_KEY] === true) return [];
+    if (existing !== null && existing.metadata[SLACK_BACKFILLED_METADATA_KEY] === true) {
+      return [];
+    }
+
+    // Cold path (first ever touch, or partial backfill from a prior crash):
+    // findOrCreate is required to create the session row before we can
+    // setMetadata against it.
+    const session =
+      existing ??
+      (await this.opts.sessionStore.findOrCreate(this.opts.sessionPolicy.channelKind, ref, tenant));
 
     const threading = readThreading(liveEvent.threading);
     const result = await this.opts.webClient.conversations.replies({

--- a/packages/adapter-store-pgvector/src/__integration__/session-store.integration.test.ts
+++ b/packages/adapter-store-pgvector/src/__integration__/session-store.integration.test.ts
@@ -82,6 +82,41 @@ describe.skipIf(!integration)('PgvectorSessionStore', () => {
     expect(last3.map((t) => t.contentText)).toEqual(['c', 'd', 'e']);
   });
 
+  it('findByRef returns null when no row matches and is read-only (no UPSERT side effect)', async () => {
+    const store = new PgvectorSessionStore(pool);
+    // Read against a never-touched ref.
+    const missing = await store.findByRef('slack', 'slack:C-findByRef-ghost:1.0', 'default');
+    expect(missing).toBeNull();
+
+    // The lookup must not have created a row — a subsequent findOrCreate
+    // is the FIRST creation and gets fresh started_at/last_active_at.
+    const created = await store.findOrCreate('slack', 'slack:C-findByRef-ghost:1.0', 'default');
+    expect(created.startedAt.getTime()).toBe(created.lastActiveAt.getTime());
+  });
+
+  it('findByRef returns the existing session without touching last_active_at', async () => {
+    const store = new PgvectorSessionStore(pool);
+    const created = await store.findOrCreate('slack', 'slack:C-findByRef-hit:1.0', 'default');
+
+    await new Promise((r) => setTimeout(r, 50));
+    const found = await store.findByRef('slack', 'slack:C-findByRef-hit:1.0', 'default');
+    expect(found).not.toBeNull();
+    expect(found?.id).toBe(created.id);
+    // findByRef is a SELECT — last_active_at must NOT have moved forward
+    // (which is what distinguishes it from findOrCreate's UPSERT touch).
+    expect(found?.lastActiveAt.getTime()).toBe(created.lastActiveAt.getTime());
+  });
+
+  it('findByRef isolates by tenant', async () => {
+    const store = new PgvectorSessionStore(pool);
+    await pool.query(
+      "INSERT INTO tenants (id, display_name) VALUES ('tenant-a', 'A'), ('tenant-b', 'B') ON CONFLICT (id) DO NOTHING",
+    );
+    await store.findOrCreate('slack', 'slack:C-findByRef-tenant:1.0', 'tenant-a');
+    const otherTenant = await store.findByRef('slack', 'slack:C-findByRef-tenant:1.0', 'tenant-b');
+    expect(otherTenant).toBeNull();
+  });
+
   it('updateStatus transitions session.status', async () => {
     const store = new PgvectorSessionStore(pool);
     const session = await store.findOrCreate('slack', 'slack:C-status:1.0', 'default');

--- a/packages/adapter-store-pgvector/src/session-store/pgvector-session-store.ts
+++ b/packages/adapter-store-pgvector/src/session-store/pgvector-session-store.ts
@@ -97,6 +97,23 @@ export class PgvectorSessionStore implements SessionStore {
     return mapSession(row);
   }
 
+  async findByRef(
+    channelKind: ChannelKind,
+    channelNativeRef: ChannelNativeRef,
+    tenantId: TenantId,
+  ): Promise<Session | null> {
+    const result = await this.pool.query<SessionRow>(
+      `SELECT * FROM sessions
+       WHERE tenant_id = $1
+         AND channel_kind = $2
+         AND channel_native_ref = $3
+       LIMIT 1`,
+      [tenantId, channelKind, channelNativeRef],
+    );
+    const row = result.rows[0];
+    return row ? mapSession(row) : null;
+  }
+
   async recordTurn(sessionId: SessionId, turn: TurnInput): Promise<Turn> {
     const result = await this.pool.query<TurnRow>(
       `INSERT INTO turns (

--- a/packages/core/src/ports/session-store.test.ts
+++ b/packages/core/src/ports/session-store.test.ts
@@ -54,6 +54,17 @@ function buildFake(): SessionStore {
       return session;
     },
 
+    async findByRef(
+      channelKind: ChannelKind,
+      channelNativeRef: ChannelNativeRef,
+      tenantId: TenantId,
+    ): Promise<Session | null> {
+      const key = `${tenantId}|${channelKind}|${channelNativeRef}`;
+      const existingId = sessionByKey.get(key);
+      if (existingId === undefined) return null;
+      return sessions.get(existingId) ?? null;
+    },
+
     async recordTurn(sessionId: SessionId, input: TurnInput): Promise<Turn> {
       turnCounter += 1;
       const turn: Turn = {
@@ -112,6 +123,11 @@ describe('SessionStore port', () => {
     const a = await store.findOrCreate('slack', 'slack:C1:1.0', 'default');
     const aAgain = await store.findOrCreate('slack', 'slack:C1:1.0', 'default');
     expect(aAgain.id).toBe(a.id);
+
+    const found = await store.findByRef('slack', 'slack:C1:1.0', 'default');
+    expect(found?.id).toBe(a.id);
+    const missing = await store.findByRef('slack', 'slack:nonexistent', 'default');
+    expect(missing).toBeNull();
 
     const b = await store.findOrCreate('slack', 'slack:C2:2.0', 'default');
     expect(b.id).not.toBe(a.id);

--- a/packages/core/src/ports/session-store.ts
+++ b/packages/core/src/ports/session-store.ts
@@ -20,6 +20,17 @@ export interface SessionStore {
     tenantId: TenantId,
   ): Promise<Session>;
 
+  // Read-only counterpart of findOrCreate. Returns null when no session
+  // exists for the (kind, ref, tenant) tuple. Callers that only need to
+  // CHECK existence or read metadata (e.g., session-bootstrap hooks
+  // deciding whether their work is already done) should use this instead
+  // of findOrCreate to avoid the UPSERT roundtrip on the hot path.
+  findByRef(
+    channelKind: ChannelKind,
+    channelNativeRef: ChannelNativeRef,
+    tenantId: TenantId,
+  ): Promise<Session | null>;
+
   recordTurn(sessionId: SessionId, turn: TurnInput): Promise<Turn>;
 
   getRecentTurns(sessionId: SessionId, limit: number): Promise<readonly Turn[]>;

--- a/packages/testing/src/session-store/in-memory-session-store.test.ts
+++ b/packages/testing/src/session-store/in-memory-session-store.test.ts
@@ -36,4 +36,44 @@ describe('InMemorySessionStore', () => {
     const recent = await store.getRecentTurns(session.id, 2);
     expect(recent.map((r) => r.contentText)).toEqual(['b', 'c']);
   });
+
+  describe('findByRef', () => {
+    it('returns null when no session exists for the (kind, ref, tenant) tuple', async () => {
+      const store = new InMemorySessionStore();
+      const result = await store.findByRef('test', 'thread-missing', 'tenant-1');
+      expect(result).toBeNull();
+    });
+
+    it('returns the existing session without creating one', async () => {
+      const store = new InMemorySessionStore();
+      const created = await store.findOrCreate('test', 'thread-1', 'tenant-1');
+      const found = await store.findByRef('test', 'thread-1', 'tenant-1');
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe(created.id);
+    });
+
+    it('does not create a session as a side effect of the read', async () => {
+      const store = new InMemorySessionStore();
+      await store.findByRef('test', 'thread-ghost', 'tenant-1');
+      // A subsequent findOrCreate must produce the FIRST session id, proving
+      // the prior findByRef did not create one.
+      const created = await store.findOrCreate('test', 'thread-ghost', 'tenant-1');
+      expect(created.id).toBe('session-1');
+    });
+
+    it('isolates by tenant', async () => {
+      const store = new InMemorySessionStore();
+      await store.findOrCreate('test', 'thread-1', 'tenant-1');
+      const otherTenant = await store.findByRef('test', 'thread-1', 'tenant-2');
+      expect(otherTenant).toBeNull();
+    });
+
+    it('reflects metadata mutations made via setMetadata', async () => {
+      const store = new InMemorySessionStore();
+      const session = await store.findOrCreate('test', 'thread-1', 'tenant-1');
+      await store.setMetadata(session.id, { slackBackfilled: true });
+      const found = await store.findByRef('test', 'thread-1', 'tenant-1');
+      expect(found?.metadata.slackBackfilled).toBe(true);
+    });
+  });
 });

--- a/packages/testing/src/session-store/in-memory-session-store.ts
+++ b/packages/testing/src/session-store/in-memory-session-store.ts
@@ -55,6 +55,17 @@ export class InMemorySessionStore implements SessionStore {
     return created;
   }
 
+  async findByRef(
+    channelKind: ChannelKind,
+    channelNativeRef: ChannelNativeRef,
+    tenantId: TenantId,
+  ): Promise<Session | null> {
+    const key = this.indexKey(channelKind, channelNativeRef, tenantId);
+    const existingId = this.nativeIndex.get(key);
+    if (existingId === undefined) return null;
+    return this.sessions.get(existingId) ?? null;
+  }
+
   async recordTurn(sessionId: SessionId, turn: TurnInput): Promise<Turn> {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Session not found: ${sessionId}`);


### PR DESCRIPTION
## Summary

PR A of the #64/#63 series. Adds a read-only counterpart to `findOrCreate` and uses it to keep the per-mention UPSERT off Slack's hot path when the session is already backfilled.

### Port change (core)
```ts
SessionStore.findByRef(
  channelKind: ChannelKind,
  channelNativeRef: ChannelNativeRef,
  tenantId: TenantId,
): Promise<Session | null>
```
Read-only — no UPSERT side effect. Returns `null` when no session exists for the `(kind, ref, tenant)` tuple.

### Adapter implementations
- **`PgvectorSessionStore`**: single `SELECT` on the unique index. Verified by integration test that `findByRef` does NOT touch `last_active_at` (which is what distinguishes it from `findOrCreate`'s UPSERT touch).
- **`InMemorySessionStore`** (testing): `nativeIndex` Map lookup, returns `null` when absent.
- The port-smoke fake in `packages/core` updated too — these test files are excluded from `pnpm typecheck`, so the port-implementation contract has to be locked in by hand.

### Slack backfiller short-circuit (the #64 fix proper)
```ts
const existing = await sessionStore.findByRef(...);
if (existing !== null && existing.metadata[SLACK_BACKFILLED_METADATA_KEY] === true) {
  return [];   // hot path: no UPSERT, no Slack API
}
const session = existing ?? await sessionStore.findOrCreate(...);  // cold path
```

A new test asserts `findOrCreate` is NOT called on the already-backfilled hot path — locks in the contract change. Also adds the symmetric "skips findOrCreate when an existing-but-not-yet-backfilled session is returned" case (cold path on existing session) and the "falls back to findOrCreate when no session exists yet" cold path (first ever touch).

## Verification

### Unit / lint / build
- `pnpm typecheck` clean
- `pnpm lint` clean (0 errors; 6 pre-existing infos on unchanged files)
- `pnpm test` clean (225 passed, 29 skipped — +7 new `findByRef` and Slack hot-path tests)
- `pnpm depcheck` clean

### Integration (against the running compose container)
```
INTEGRATION=1 pnpm vitest run src/__integration__/session-store.integration.test.ts
# 9 passed (1 skipped) — 3 new findByRef integration tests:
#  - returns null when no row matches (read-only, no UPSERT side effect)
#  - returns the existing session without touching last_active_at
#  - isolates by tenant
```

The `last_active_at` non-touch assertion is the key contract proof — `findByRef` is genuinely a `SELECT`, not a disguised UPSERT.

## Out of scope (handled by PR B / #63)

- Architectural relocation (move backfill off the ack path)
- `SessionFirstTouch` port introduction
- `SlackInboundChannel` simplification (drop the `backfiller` option)
- Removal of the in-memory `inFlight` dedup Map (still needed for cold-path concurrency in PR A; PR B replaces it with JobRunner per-key FIFO)

PR B is sequential — do not merge in parallel. PR B's diff is hard to review until PR A is on main.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors; 6 pre-existing infos)
- [x] `pnpm test` clean (225 passed)
- [x] `pnpm depcheck` clean
- [x] `INTEGRATION=1 pnpm vitest run src/__integration__/session-store.integration.test.ts` — 9 passed (3 new findByRef contract tests)

Refs #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)