### PR TITLE
feat(core,slack,runtime,server,testing): SessionFirstTouch port + Slack ack-path purification (#63)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -458,6 +458,49 @@ Switch from in-memory if **any one** of the following holds:
 If none apply (single VPS, single process, light traffic, Slack retry tolerance
 acceptable), in-memory remains the right choice. Implementation tracked in #28.
 
+### 4.9 SessionFirstTouch — issue #63
+
+```ts
+interface SessionFirstTouchInput {
+  readonly session: Session;
+  readonly event: IncomingEvent;
+}
+
+interface SessionFirstTouch {
+  /**
+   * Channel-agnostic session-bootstrap hook. Invoked by the use case
+   * INSIDE the JobRunner queue (off the inbound ack path) on each
+   * session's first contact. Returns synthetic IncomingEvents the use
+   * case records as user turns BEFORE the live event's agent run.
+   *
+   * Implementations own their "already done" flag (typically via
+   * `session.metadata`) and reconcile multi-process drift via
+   * `SessionStore.findByRef` — the closure-captured `session` is per-
+   * worker stale.
+   *
+   * Failure semantics: if the impl throws, the use case logs and still
+   * processes the live event. Synthetic delivery is best-effort.
+   */
+  onFirstTouch(input: SessionFirstTouchInput): Promise<readonly IncomingEvent[]>;
+}
+```
+
+**Why this is a port, not a Slack helper**: Slack's "fetch prior thread
+messages on first mention" was previously hard-coded into
+`SlackInboundChannel`. That blocked the 3-second ack budget on a Slack
+API call AND assumed the ack path owned session-bootstrap concerns.
+Promoting it to a core port lets Discord / CLI / HTTP adapters plug in
+the same way (or opt out by registering nothing). Concurrency
+consolidates to a single primitive (JobRunner per-key FIFO) — the
+adapter no longer carries its own in-flight Map.
+
+**Default**: none. Channels register an impl in `BuildChannelsResult.sessionFirstTouches`.
+
+**MVP impl**: `SlackHistoryBackfiller` (in `adapter-channel-slack`)
+— closure-snapshot check on `session.metadata.slackBackfilled`,
+`findByRef` race re-check, then `conversations.replies(limit:1000)` on
+the cold path.
+
 ---
 
 ## 5. Use Cases
@@ -471,21 +514,32 @@ business logic lives.
 IncomingEvent
    │
    ▼
-SessionStore.findOrCreate ──► Session
+SessionStore.findOrCreate ──► Session         ◄── only DB roundtrip on ack path
    │
-   ▼ (if Slack synthetic-history needed: emit prior IncomingEvents first)
-JobRunner.enqueue(key=sessionId, job=processOneTurn)
+   ▼
+JobRunner.enqueue(key=sessionId, job=…)       ◄── ack returns here
    │
    ▼  (per-key serial)
-[processOneTurn]
+[queued job]
    │
-   ├── SessionStore.recordTurn(user)
-   ├── KnowledgeStore.retrieve(query=user.text, tenantId)
-   ├── AgentRunner.run({ prompt, context.retrievedKnowledge })
-   │     └── consume AgentEvents
-   ├── SessionStore.recordTurn(agent, metadata.usage)
-   └── OutboundChannel.reply(target, response)
+   ├── SessionFirstTouch.onFirstTouch?(...) → synthetics  (off ack path)
+   │     └── for each synthetic: processOneTurn(synth)
+   │
+   └── processOneTurn(live event)
+         │
+         ├── SessionStore.recordTurn(user)
+         ├── KnowledgeStore.retrieve(query=user.text, tenantId)
+         ├── AgentRunner.run({ prompt, context.retrievedKnowledge })
+         │     └── consume AgentEvents
+         ├── SessionStore.recordTurn(agent, metadata.usage)
+         └── OutboundChannel.reply(target, response)
 ```
+
+**Boundary**: `findOrCreate` + `enqueue` are synchronous from the
+inbound channel's perspective (Slack's 3s ack budget). Everything else
+— including `SessionFirstTouch` — runs inside the queued job. First-
+touch failure is swallowed (logged) so a transient Slack API error
+during backfill cannot drop the live mention.
 
 ### 5.2 DistillSession (Phase 2 implementation)
 

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -1,11 +1,12 @@
 import {
+  SLACK_CHANNEL_KIND,
   SlackHistoryBackfiller,
   SlackInboundChannel,
   SlackOutboundChannel,
   SlackSessionPolicy,
   slackMcpServerConfig,
 } from '@agentry/adapter-channel-slack';
-import type { ChannelKind, OutboundChannel, SessionPolicy } from '@agentry/core';
+import type { ChannelKind, OutboundChannel, SessionFirstTouch, SessionPolicy } from '@agentry/core';
 import { AgentryConfigSchema, compose, loadSecrets } from '@agentry/runtime';
 import { serve } from '@hono/node-server';
 import { WebClient } from '@slack/web-api';
@@ -41,7 +42,7 @@ async function main(): Promise<void> {
   const handles = await compose({
     config,
     secrets,
-    buildChannels: ({ sessionStore }) => {
+    buildChannels: ({ sessionStore, logger }) => {
       // Single shared WebClient: SlackOutboundChannel posts replies; the
       // backfiller fetches conversations.replies. Two clients would just
       // duplicate connection pools.
@@ -55,17 +56,20 @@ async function main(): Promise<void> {
         webClient: slackClient,
         sessionStore,
         sessionPolicy: policy,
+        logger,
       });
       const inbound = new SlackInboundChannel({
         botToken: secrets.SLACK_BOT_TOKEN,
         signingSecret: secrets.SLACK_SIGNING_SECRET,
         port: slackPort,
-        backfiller,
       });
       return {
         inboundChannels: [inbound],
         outboundChannels: new Map<ChannelKind, OutboundChannel>([[policy.channelKind, outbound]]),
         sessionPolicies: new Map<ChannelKind, SessionPolicy>([[policy.channelKind, policy]]),
+        sessionFirstTouches: new Map<ChannelKind, SessionFirstTouch>([
+          [SLACK_CHANNEL_KIND, backfiller],
+        ]),
         mcpServers: [slackMcpServerConfig({ botToken: secrets.SLACK_BOT_TOKEN })],
       };
     },

--- a/packages/adapter-channel-slack/src/slack-history-backfiller.test.ts
+++ b/packages/adapter-channel-slack/src/slack-history-backfiller.test.ts
@@ -68,30 +68,23 @@ function makeSession(overrides: Partial<Session> = {}): Session {
 }
 
 interface FakeSessionStore extends SessionStore {
-  readonly findOrCreateMock: ReturnType<typeof vi.fn>;
   readonly findByRefMock: ReturnType<typeof vi.fn>;
+  readonly findOrCreateMock: ReturnType<typeof vi.fn>;
   readonly setMetadataMock: ReturnType<typeof vi.fn>;
 }
 
 interface MakeSessionStoreOptions {
-  // null models the "no session exists yet" cold path; findByRef returns
-  // null and the backfiller falls back to findOrCreate.
-  readonly initial?: Session | null;
+  // Returned by findByRef. Defaults to the same baseline session — model
+  // a sibling-process race by overriding metadata here.
+  readonly fresh?: Session | null;
 }
 
 function makeSessionStore(options: MakeSessionStoreOptions = {}): FakeSessionStore {
-  let current: Session | null = options.initial === undefined ? makeSession() : options.initial;
-  const findByRefMock = vi.fn(async () => current);
-  const findOrCreateMock = vi.fn(async () => {
-    if (current === null) current = makeSession();
-    return current;
-  });
+  const fresh = options.fresh === undefined ? makeSession() : options.fresh;
+  const findByRefMock = vi.fn(async () => fresh);
+  const findOrCreateMock = vi.fn(async () => makeSession());
   const setMetadataMock = vi.fn(
-    async (_id: SessionId, patch: Readonly<Record<string, unknown>>) => {
-      if (current !== null) {
-        current = { ...current, metadata: { ...current.metadata, ...patch } };
-      }
-    },
+    async (_id: SessionId, _patch: Readonly<Record<string, unknown>>) => {},
   );
   return {
     findOrCreate: findOrCreateMock as SessionStore['findOrCreate'],
@@ -103,8 +96,8 @@ function makeSessionStore(options: MakeSessionStoreOptions = {}): FakeSessionSto
     getRecentTurns: vi.fn(async (_id: SessionId, _l: number) => []),
     updateStatus: vi.fn(async (_id: SessionId, _s: SessionStatus) => {}),
     listSessionsForDistillation: vi.fn(async (_c: DistillationCriteria) => []),
-    findOrCreateMock,
     findByRefMock,
+    findOrCreateMock,
     setMetadataMock,
   };
 }
@@ -137,66 +130,75 @@ const liveEvent: IncomingEvent = {
   idempotencyKey: 'EvLive',
 };
 
-describe('SlackHistoryBackfiller', () => {
-  it('returns [] without calling Slack OR findOrCreate when session is already backfilled (#64)', async () => {
-    const store = makeSessionStore({
-      initial: makeSession({ metadata: { [SLACK_BACKFILLED_METADATA_KEY]: true } }),
-    });
+function call(
+  backfiller: SlackHistoryBackfiller,
+  session: Session,
+  event = liveEvent,
+): Promise<readonly IncomingEvent[]> {
+  return backfiller.onFirstTouch({ session, event });
+}
+
+describe('SlackHistoryBackfiller (SessionFirstTouch impl)', () => {
+  it('returns [] without calling Slack OR findByRef when closure session is already backfilled', async () => {
+    const store = makeSessionStore();
     const repliesFn = vi.fn();
-    const webClient = makeWebClient(repliesFn);
     const backfiller = new SlackHistoryBackfiller({
-      webClient,
+      webClient: makeWebClient(repliesFn),
       sessionStore: store,
       sessionPolicy: new StubSlackPolicy(),
     });
 
-    const result = await backfiller.backfillIfNeeded(liveEvent, 'default');
+    const session = makeSession({ metadata: { [SLACK_BACKFILLED_METADATA_KEY]: true } });
+    const result = await call(backfiller, session);
 
     expect(result).toEqual([]);
     expect(repliesFn).not.toHaveBeenCalled();
     expect(store.setMetadataMock).not.toHaveBeenCalled();
-    // The whole point of #64: the per-mention UPSERT is gone on the hot path.
-    expect(store.findOrCreateMock).not.toHaveBeenCalled();
-    expect(store.findByRefMock).toHaveBeenCalledTimes(1);
+    expect(store.findByRefMock).not.toHaveBeenCalled();
   });
 
-  it('skips findOrCreate when an existing-but-not-yet-backfilled session is returned by findByRef', async () => {
+  it('returns [] when closure says not-backfilled but findByRef shows sibling-process beat us to it', async () => {
+    // Defense-in-depth path: closure snapshot is from BEFORE a sibling
+    // process flipped the flag. Re-read via findByRef catches it.
     const store = makeSessionStore({
-      initial: makeSession({ metadata: {} }),
+      fresh: makeSession({ metadata: { [SLACK_BACKFILLED_METADATA_KEY]: true } }),
     });
+    const repliesFn = vi.fn();
     const backfiller = new SlackHistoryBackfiller({
-      webClient: makeWebClient(async () => ({ ok: true, messages: [] })),
+      webClient: makeWebClient(repliesFn),
       sessionStore: store,
       sessionPolicy: new StubSlackPolicy(),
     });
 
-    await backfiller.backfillIfNeeded(liveEvent, 'default');
+    const stale = makeSession({ metadata: {} });
+    const result = await call(backfiller, stale);
+
+    expect(result).toEqual([]);
+    expect(store.findByRefMock).toHaveBeenCalledTimes(1);
+    expect(repliesFn).not.toHaveBeenCalled();
+    expect(store.setMetadataMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches conversations.replies + setMetadata when both closure and findByRef say not-backfilled', async () => {
+    const store = makeSessionStore({ fresh: makeSession({ metadata: {} }) });
+    const repliesFn = vi.fn(async () => ({ ok: true, messages: [] }));
+    const backfiller = new SlackHistoryBackfiller({
+      webClient: makeWebClient(repliesFn),
+      sessionStore: store,
+      sessionPolicy: new StubSlackPolicy(),
+    });
+
+    await call(backfiller, makeSession({ metadata: {} }));
 
     expect(store.findByRefMock).toHaveBeenCalledTimes(1);
-    // Existing session reused — no UPSERT needed.
-    expect(store.findOrCreateMock).not.toHaveBeenCalled();
-    // Backfill marker still gets persisted on the existing session id.
+    expect(repliesFn).toHaveBeenCalledTimes(1);
     expect(store.setMetadataMock).toHaveBeenCalledWith('sess-1', {
       [SLACK_BACKFILLED_METADATA_KEY]: true,
     });
   });
 
-  it('falls back to findOrCreate when no session exists yet (cold path, first ever touch)', async () => {
-    const store = makeSessionStore({ initial: null });
-    const backfiller = new SlackHistoryBackfiller({
-      webClient: makeWebClient(async () => ({ ok: true, messages: [] })),
-      sessionStore: store,
-      sessionPolicy: new StubSlackPolicy(),
-    });
-
-    await backfiller.backfillIfNeeded(liveEvent, 'default');
-
-    expect(store.findByRefMock).toHaveBeenCalledTimes(1);
-    expect(store.findOrCreateMock).toHaveBeenCalledTimes(1);
-  });
-
   it('maps prior thread messages to synthetic IncomingEvents in chronological order', async () => {
-    const store = makeSessionStore({});
+    const store = makeSessionStore({ fresh: makeSession({ metadata: {} }) });
     const repliesFn = vi.fn(async () => ({
       ok: true,
       messages: [
@@ -211,7 +213,7 @@ describe('SlackHistoryBackfiller', () => {
       sessionPolicy: new StubSlackPolicy(),
     });
 
-    const result = await backfiller.backfillIfNeeded(liveEvent, 'default');
+    const result = await call(backfiller, makeSession({ metadata: {} }));
 
     expect(result).toHaveLength(2);
     expect(result.map((e) => e.idempotencyKey)).toEqual([
@@ -235,7 +237,7 @@ describe('SlackHistoryBackfiller', () => {
   });
 
   it('excludes bot_id messages so bot replies are not recorded as user turns', async () => {
-    const store = makeSessionStore({});
+    const store = makeSessionStore({ fresh: makeSession({ metadata: {} }) });
     const repliesFn = vi.fn(async () => ({
       ok: true,
       messages: [
@@ -250,85 +252,35 @@ describe('SlackHistoryBackfiller', () => {
       sessionPolicy: new StubSlackPolicy(),
     });
 
-    const result = await backfiller.backfillIfNeeded(liveEvent, 'default');
+    const result = await call(backfiller, makeSession({ metadata: {} }));
 
     expect(result.map((e) => e.author.channelUserId)).toEqual(['U1', 'U2']);
   });
 
-  it('marks the session backfilled after a successful first run', async () => {
-    const store = makeSessionStore({});
-    const backfiller = new SlackHistoryBackfiller({
-      webClient: makeWebClient(async () => ({ ok: true, messages: [] })),
-      sessionStore: store,
-      sessionPolicy: new StubSlackPolicy(),
-    });
-
-    await backfiller.backfillIfNeeded(liveEvent, 'default');
-
-    expect(store.setMetadataMock).toHaveBeenCalledWith('sess-1', {
-      [SLACK_BACKFILLED_METADATA_KEY]: true,
-    });
-  });
-
   it('throws SlackHistoryBackfillError when conversations.replies returns ok: false', async () => {
-    const store = makeSessionStore({});
+    const store = makeSessionStore({ fresh: makeSession({ metadata: {} }) });
     const backfiller = new SlackHistoryBackfiller({
       webClient: makeWebClient(async () => ({ ok: false, error: 'channel_not_found' })),
       sessionStore: store,
       sessionPolicy: new StubSlackPolicy(),
     });
 
-    await expect(backfiller.backfillIfNeeded(liveEvent, 'default')).rejects.toBeInstanceOf(
+    await expect(call(backfiller, makeSession({ metadata: {} }))).rejects.toBeInstanceOf(
       SlackHistoryBackfillError,
     );
     expect(store.setMetadataMock).not.toHaveBeenCalled();
   });
 
-  it('collapses concurrent first-touch calls into a single Slack API request', async () => {
-    const store = makeSessionStore({});
-    let resolve!: (value: ConversationsRepliesResult) => void;
-    const inflight = new Promise<ConversationsRepliesResult>((r) => {
-      resolve = r;
-    });
-    const repliesFn = vi.fn(async () => inflight);
+  it('does not call findOrCreate — the use case provides the session row', async () => {
+    const store = makeSessionStore({ fresh: makeSession({ metadata: {} }) });
     const backfiller = new SlackHistoryBackfiller({
-      webClient: makeWebClient(repliesFn),
+      webClient: makeWebClient(async () => ({ ok: true, messages: [] })),
       sessionStore: store,
       sessionPolicy: new StubSlackPolicy(),
     });
 
-    const a = backfiller.backfillIfNeeded(liveEvent, 'default');
-    const b = backfiller.backfillIfNeeded(liveEvent, 'default');
+    await call(backfiller, makeSession({ metadata: {} }));
 
-    await vi.waitFor(() => {
-      expect(repliesFn).toHaveBeenCalledTimes(1);
-    });
-    resolve({ ok: true, messages: [] });
-    const [resA, resB] = await Promise.all([a, b]);
-    expect(repliesFn).toHaveBeenCalledTimes(1);
-    expect(resA).toEqual([]);
-    expect(resB).toEqual([]);
-  });
-
-  it('does not poison the lock when a backfill throws — next call retries', async () => {
-    const store = makeSessionStore({});
-    let calls = 0;
-    const repliesFn = vi.fn(async () => {
-      calls += 1;
-      if (calls === 1) return { ok: false, error: 'rate_limited' };
-      return { ok: true, messages: [] };
-    });
-    const backfiller = new SlackHistoryBackfiller({
-      webClient: makeWebClient(repliesFn),
-      sessionStore: store,
-      sessionPolicy: new StubSlackPolicy(),
-    });
-
-    await expect(backfiller.backfillIfNeeded(liveEvent, 'default')).rejects.toBeInstanceOf(
-      SlackHistoryBackfillError,
-    );
-    const second = await backfiller.backfillIfNeeded(liveEvent, 'default');
-    expect(second).toEqual([]);
-    expect(repliesFn).toHaveBeenCalledTimes(2);
+    expect(store.findOrCreateMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/adapter-channel-slack/src/slack-history-backfiller.ts
+++ b/packages/adapter-channel-slack/src/slack-history-backfiller.ts
@@ -1,10 +1,11 @@
 import {
-  type ChannelNativeRef,
   type IncomingEvent,
+  type Logger,
+  type SessionFirstTouch,
+  type SessionFirstTouchInput,
   type SessionPolicy,
   type SessionStore,
   SYNTHETIC_EVENT_METADATA_KEY,
-  type TenantId,
   type ThreadingMetadata,
 } from '@agentry/core';
 import type { WebClient } from '@slack/web-api';
@@ -29,6 +30,7 @@ export interface SlackHistoryBackfillerOptions {
   readonly webClient: WebClient;
   readonly sessionStore: SessionStore;
   readonly sessionPolicy: SessionPolicy;
+  readonly logger?: Logger;
 }
 
 export class SlackHistoryBackfillError extends Error {
@@ -38,72 +40,68 @@ export class SlackHistoryBackfillError extends Error {
   }
 }
 
-export class SlackHistoryBackfiller {
+const noopLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => noopLogger,
+};
+
+// Channel-agnostic core hook implemented for Slack: backfills prior thread
+// messages as synthetic IncomingEvents the use case records as user turns
+// before the live mention. Single-process dedup comes from the JobRunner
+// per-key FIFO contract; multi-process race is re-confirmed via
+// SessionStore.findByRef before any work runs.
+export class SlackHistoryBackfiller implements SessionFirstTouch {
   private readonly opts: SlackHistoryBackfillerOptions;
-  // In-memory promise lock keyed by nativeRef collapses concurrent
-  // first-touch events for the same session into one Slack API call. The
-  // persistent `slackBackfilled` metadata flag covers the cross-restart
-  // case; this map covers the single-process race window. Multi-instance
-  // deployments still have a narrow same-session-different-process race
-  // (accepted for the MVP).
-  private readonly inFlight = new Map<ChannelNativeRef, Promise<readonly IncomingEvent[]>>();
+  private readonly log: Logger;
 
   constructor(opts: SlackHistoryBackfillerOptions) {
     this.opts = opts;
+    this.log = opts.logger ?? noopLogger;
   }
 
-  async backfillIfNeeded(
-    liveEvent: IncomingEvent,
-    tenant: TenantId,
-  ): Promise<readonly IncomingEvent[]> {
-    const ref = this.opts.sessionPolicy.computeNativeRef(liveEvent);
-    const existing = this.inFlight.get(ref);
-    if (existing) return existing;
-    const promise = this.runBackfill(liveEvent, tenant, ref);
-    this.inFlight.set(ref, promise);
-    try {
-      return await promise;
-    } finally {
-      this.inFlight.delete(ref);
-    }
-  }
+  async onFirstTouch(input: SessionFirstTouchInput): Promise<readonly IncomingEvent[]> {
+    const { session, event } = input;
 
-  private async runBackfill(
-    liveEvent: IncomingEvent,
-    tenant: TenantId,
-    ref: ChannelNativeRef,
-  ): Promise<readonly IncomingEvent[]> {
-    // Hot-path short-circuit: if the session already exists AND is
-    // backfilled, skip the UPSERT and the Slack API call entirely. The
-    // read-only `findByRef` keeps the already-backfilled mention path off
-    // the per-mention findOrCreate roundtrip (#64).
-    const existing = await this.opts.sessionStore.findByRef(
-      this.opts.sessionPolicy.channelKind,
-      ref,
-      tenant,
-    );
-    if (existing !== null && existing.metadata[SLACK_BACKFILLED_METADATA_KEY] === true) {
+    // Closure snapshot wins the cheap path: when the use case captured a
+    // session that was already marked backfilled, no Slack roundtrip
+    // needed.
+    if (session.metadata[SLACK_BACKFILLED_METADATA_KEY] === true) {
+      this.log.info({ sessionId: session.id }, 'slack first-touch: skipped (already backfilled)');
       return [];
     }
 
-    // Cold path (first ever touch, or partial backfill from a prior crash):
-    // findOrCreate is required to create the session row before we can
-    // setMetadata against it.
-    const session =
-      existing ??
-      (await this.opts.sessionStore.findOrCreate(this.opts.sessionPolicy.channelKind, ref, tenant));
+    // Defense-in-depth for the per-key-FIFO + multi-process race: the
+    // captured session is from BEFORE enqueue, so a sibling job (this
+    // process or another) that finished backfilling between findOrCreate
+    // and now is invisible to the closure. Re-read fresh.
+    const ref = this.opts.sessionPolicy.computeNativeRef(event);
+    const fresh = await this.opts.sessionStore.findByRef(
+      this.opts.sessionPolicy.channelKind,
+      ref,
+      session.tenantId,
+    );
+    if (fresh !== null && fresh.metadata[SLACK_BACKFILLED_METADATA_KEY] === true) {
+      this.log.info(
+        { sessionId: session.id },
+        'slack first-touch: skipped (already backfilled by sibling)',
+      );
+      return [];
+    }
 
-    const threading = readThreading(liveEvent.threading);
+    const threading = readThreading(event.threading);
     const result = await this.opts.webClient.conversations.replies({
       channel: threading.channel,
       ts: threading.thread_ts,
       // Slack returns replies oldest-first, one page at a time. With
       // limit: 1000 (Slack's max), a thread of >1000 messages truncates
       // the MOST RECENT tail — i.e. the part the agent most needs for
-      // context. Slack's 3-second ack budget rules out multi-page fetch
-      // on the inbound hot path. Followup work: invert pagination (latest
-      // first) and/or move backfill off the ack path if real threads
-      // start hitting the cap.
+      // context. Followup work: invert pagination (latest first) and/or
+      // bulk-recordTurn for very long threads.
       limit: 1000,
     });
     if (!result.ok || !result.messages) {
@@ -129,6 +127,10 @@ export class SlackHistoryBackfiller {
     await this.opts.sessionStore.setMetadata(session.id, {
       [SLACK_BACKFILLED_METADATA_KEY]: true,
     });
+    this.log.info(
+      { sessionId: session.id, synthetics: synthetics.length },
+      'slack first-touch: backfilled N messages from conversations.replies',
+    );
     return synthetics;
   }
 }

--- a/packages/adapter-channel-slack/src/slack-inbound-channel.test.ts
+++ b/packages/adapter-channel-slack/src/slack-inbound-channel.test.ts
@@ -1,12 +1,6 @@
-import {
-  type IncomingEvent,
-  type Logger,
-  SYNTHETIC_EVENT_METADATA_KEY,
-  type TenantId,
-} from '@agentry/core';
+import type { IncomingEvent, Logger } from '@agentry/core';
 import type { App } from '@slack/bolt';
 import { describe, expect, it, vi } from 'vitest';
-import type { SlackHistoryBackfiller } from './slack-history-backfiller.js';
 import { SlackInboundChannel } from './slack-inbound-channel.js';
 
 // dep-cruiser forbids adapter-* → @agentry/testing imports (the testing
@@ -140,7 +134,7 @@ describe('SlackInboundChannel', () => {
     await first;
   });
 
-  it('forwards mapped IncomingEvent to handler when app_mention fires', async () => {
+  it('forwards mapped IncomingEvent to handler when app_mention fires (no synthetic backfill on ack path)', async () => {
     const { app, captured } = fakeApp();
     const seen: IncomingEvent[] = [];
     const ch = new SlackInboundChannel({
@@ -168,149 +162,14 @@ describe('SlackInboundChannel', () => {
       logger: silentLogger,
     });
 
+    // Single dispatch — the use case's SessionFirstTouch hook handles
+    // history backfill inside the JobRunner queue, not here.
     expect(seen).toHaveLength(1);
     expect(seen[0]).toMatchObject({
       channelKind: 'slack',
       channelNativeRef: 'slack:C9:1700000000.000100',
       idempotencyKey: 'EvX',
     });
-
-    ac.abort();
-    await startPromise;
-  });
-
-  it('forwards synthetic events from the backfiller before the live event', async () => {
-    const { app, captured } = fakeApp();
-    const seen: IncomingEvent[] = [];
-    const synthetic: IncomingEvent = {
-      channelKind: 'slack',
-      channelNativeRef: 'slack:C9:1700000000.000100',
-      author: { channelUserId: 'U9' },
-      payload: { text: 'historical' },
-      threading: {
-        channel: 'C9',
-        thread_ts: '1700000000.000100',
-        message_ts: '1700000050.000100',
-        team_id: 'T1',
-      },
-      receivedAt: new Date(1_700_000_050_000),
-      idempotencyKey: 'slack-history:1700000050.000100',
-      metadata: { [SYNTHETIC_EVENT_METADATA_KEY]: true },
-    };
-    const backfiller = {
-      backfillIfNeeded: vi.fn(async () => [synthetic]),
-    } as unknown as SlackHistoryBackfiller;
-    const ch = new SlackInboundChannel({
-      ...baseOpts,
-      app,
-      backfiller,
-      fetch: fakeFetchOk(['app_mentions:read', 'chat:write', 'channels:history', 'groups:history']),
-    });
-    const ac = new AbortController();
-    const startPromise = ch.start(async (e) => {
-      seen.push(e);
-    }, ac.signal);
-    const handler = await waitForHandler(captured);
-
-    await handler({
-      event: {
-        type: 'app_mention',
-        user: 'U1',
-        text: 'hi',
-        ts: '1700000123.000200',
-        thread_ts: '1700000000.000100',
-        channel: 'C9',
-        event_ts: '1700000123.000200',
-      },
-      body: { event_id: 'EvX', team_id: 'T1' },
-      logger: silentLogger,
-    });
-
-    expect(seen.map((e) => e.idempotencyKey)).toEqual(['slack-history:1700000050.000100', 'EvX']);
-
-    ac.abort();
-    await startPromise;
-  });
-
-  it('still forwards the live event when the backfiller throws (warn logged)', async () => {
-    const { app, captured } = fakeApp();
-    const seen: IncomingEvent[] = [];
-    const warnLog = vi.fn();
-    const logger: Logger = { ...silentLogger, warn: warnLog };
-    const backfiller = {
-      backfillIfNeeded: vi.fn(async () => {
-        throw new Error('rate_limited');
-      }),
-    } as unknown as SlackHistoryBackfiller;
-    const ch = new SlackInboundChannel({
-      ...baseOpts,
-      app,
-      backfiller,
-      logger,
-      fetch: fakeFetchOk(['app_mentions:read', 'chat:write', 'channels:history', 'groups:history']),
-    });
-    const ac = new AbortController();
-    const startPromise = ch.start(async (e) => {
-      seen.push(e);
-    }, ac.signal);
-    const handler = await waitForHandler(captured);
-
-    await handler({
-      event: {
-        type: 'app_mention',
-        user: 'U1',
-        text: 'hi',
-        ts: '1700000123.000200',
-        thread_ts: '1700000000.000100',
-        channel: 'C9',
-        event_ts: '1700000123.000200',
-      },
-      body: { event_id: 'EvX', team_id: 'T1' },
-      logger,
-    });
-
-    expect(seen.map((e) => e.idempotencyKey)).toEqual(['EvX']);
-    expect(warnLog).toHaveBeenCalledOnce();
-
-    ac.abort();
-    await startPromise;
-  });
-
-  it('passes the resolveTenant result to the backfiller', async () => {
-    const { app, captured } = fakeApp();
-    const backfillIfNeeded = vi.fn(async () => []);
-    const backfiller = { backfillIfNeeded } as unknown as SlackHistoryBackfiller;
-    const resolveTenant = vi.fn((_e: IncomingEvent): TenantId => 'tenant-A');
-    const ch = new SlackInboundChannel({
-      ...baseOpts,
-      app,
-      backfiller,
-      resolveTenant,
-      fetch: fakeFetchOk(['app_mentions:read', 'chat:write', 'channels:history', 'groups:history']),
-    });
-    const ac = new AbortController();
-    const startPromise = ch.start(async () => {}, ac.signal);
-    const handler = await waitForHandler(captured);
-
-    await handler({
-      event: {
-        type: 'app_mention',
-        user: 'U1',
-        text: 'hi',
-        ts: '1700000123.000200',
-        thread_ts: '1700000000.000100',
-        channel: 'C9',
-        event_ts: '1700000123.000200',
-      },
-      body: { event_id: 'EvX', team_id: 'T1' },
-      logger: silentLogger,
-    });
-
-    expect(resolveTenant).toHaveBeenCalledOnce();
-    expect(backfillIfNeeded).toHaveBeenCalledWith(
-      expect.objectContaining({ idempotencyKey: 'EvX' }),
-      'tenant-A',
-    );
 
     ac.abort();
     await startPromise;

--- a/packages/adapter-channel-slack/src/slack-inbound-channel.ts
+++ b/packages/adapter-channel-slack/src/slack-inbound-channel.ts
@@ -1,11 +1,10 @@
-import type { ChannelKind, InboundChannel, IncomingEvent, Logger, TenantId } from '@agentry/core';
+import type { ChannelKind, InboundChannel, IncomingEvent, Logger } from '@agentry/core';
 import { App } from '@slack/bolt';
 import { SLACK_CHANNEL_KIND } from './slack-channel-kinds.js';
 import {
   mapAppMentionToIncomingEvent,
   type SlackAppMentionEnvelope,
 } from './slack-event-mapping.js';
-import type { SlackHistoryBackfiller } from './slack-history-backfiller.js';
 import { verifySlackScopes } from './slack-scope-verifier.js';
 
 // Channel mention + thread backfill + user/channel lookup scopes. Reading
@@ -22,8 +21,6 @@ export const SLACK_REQUIRED_SCOPES: readonly string[] = [
   'users:read',
 ];
 
-const DEFAULT_TENANT: TenantId = 'default';
-
 export interface SlackInboundChannelOptions {
   readonly botToken: string;
   readonly signingSecret: string;
@@ -34,11 +31,6 @@ export interface SlackInboundChannelOptions {
   readonly app?: App;
   readonly fetch?: typeof globalThis.fetch;
   readonly requiredScopes?: readonly string[];
-  // Optional thread-history backfill: when set, the channel calls
-  // backfillIfNeeded on first contact and forwards synthetic events
-  // (history-only) to the handler before the live event.
-  readonly backfiller?: SlackHistoryBackfiller;
-  readonly resolveTenant?: (event: IncomingEvent) => TenantId;
 }
 
 export class SlackInboundChannel implements InboundChannel {
@@ -85,21 +77,9 @@ export class SlackInboundChannel implements InboundChannel {
           team_id: typeof b.team_id === 'string' ? b.team_id : '',
         };
         const live = mapAppMentionToIncomingEvent(envelope);
-        const tenant = (this.opts.resolveTenant ?? (() => DEFAULT_TENANT))(live);
-
-        // Inner try/catch around backfill ONLY: a backfill failure must not
-        // drop the live event. Without this, a transient Slack API error
-        // (rate limit, network blip) would silently drop the user's mention.
-        let synthetics: readonly IncomingEvent[] = [];
-        if (this.opts.backfiller) {
-          try {
-            synthetics = await this.opts.backfiller.backfillIfNeeded(live, tenant);
-          } catch (err) {
-            log.warn({ err }, 'slack history backfill failed; proceeding without synthetics');
-          }
-        }
-
-        for (const synth of synthetics) await handler(synth);
+        // Thread-history backfill moved off the ack path: the use case
+        // invokes SessionFirstTouch inside the JobRunner queue. Inbound
+        // ack only needs to dispatch the live event.
         await handler(live);
       } catch (err) {
         // Log and swallow: failing here would cause Bolt to leave the request

--- a/packages/core/src/app/handle-incoming-message.ts
+++ b/packages/core/src/app/handle-incoming-message.ts
@@ -7,6 +7,7 @@ import type { JobRunner } from '../ports/job-runner.js';
 import type { KnowledgeStore } from '../ports/knowledge-store.js';
 import type { Logger } from '../ports/logger.js';
 import type { OutboundChannel } from '../ports/outbound-channel.js';
+import type { SessionFirstTouch } from '../ports/session-first-touch.js';
 import type { SessionPolicy } from '../ports/session-policy.js';
 import type { SessionStore } from '../ports/session-store.js';
 
@@ -17,6 +18,10 @@ export interface HandleIncomingMessageDeps {
   readonly jobRunner: JobRunner;
   readonly sessionPolicies: ReadonlyMap<ChannelKind, SessionPolicy>;
   readonly outboundChannels: ReadonlyMap<ChannelKind, OutboundChannel>;
+  // Per-channel session-bootstrap hook. When set for `event.channelKind`,
+  // it runs INSIDE the JobRunner queue (off the inbound ack path) and may
+  // return synthetic events recorded as user turns before the live event.
+  readonly sessionFirstTouches?: ReadonlyMap<ChannelKind, SessionFirstTouch>;
   readonly resolveTenant: (event: IncomingEvent) => TenantId;
   readonly agentWorkdir: string;
   readonly logger: Logger;
@@ -65,10 +70,38 @@ export function makeHandleIncomingMessage(deps: HandleIncomingMessageDeps): Hand
     const log = tenantLog.child({ sessionId: session.id });
     log.info({}, 'session resolved; enqueueing turn');
 
+    const firstTouch = deps.sessionFirstTouches?.get(event.channelKind);
+
     await deps.jobRunner.enqueue({
       key: session.id,
-      job: () =>
-        processOneTurn({ event, sessionId: session.id, tenantId, log, deps, topK, policy }),
+      // First-touch + live processing run inside the per-key FIFO chain
+      // (see InMemoryJobRunner). Mention 2 cannot start until mention 1
+      // resolves, so a single-process deployment never double-fetches
+      // history. Multi-process correctness relies on the impl re-reading
+      // session metadata via SessionStore.findByRef.
+      job: async () => {
+        if (firstTouch !== undefined) {
+          let synthetics: readonly IncomingEvent[] = [];
+          try {
+            synthetics = await firstTouch.onFirstTouch({ session, event });
+          } catch (err) {
+            // Backfill failure must not drop the live event.
+            log.warn({ err }, 'session first-touch failed; proceeding with live event only');
+          }
+          for (const synth of synthetics) {
+            await processOneTurn({
+              event: synth,
+              sessionId: session.id,
+              tenantId,
+              log,
+              deps,
+              topK,
+              policy,
+            });
+          }
+        }
+        await processOneTurn({ event, sessionId: session.id, tenantId, log, deps, topK, policy });
+      },
     });
   };
 }

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -14,5 +14,9 @@ export type {
 export type { KnowledgeStore } from './knowledge-store.js';
 export type { Logger } from './logger.js';
 export type { OutboundChannel } from './outbound-channel.js';
+export type {
+  SessionFirstTouch,
+  SessionFirstTouchInput,
+} from './session-first-touch.js';
 export type { SessionPolicy } from './session-policy.js';
 export type { SessionStore } from './session-store.js';

--- a/packages/core/src/ports/session-first-touch.ts
+++ b/packages/core/src/ports/session-first-touch.ts
@@ -1,0 +1,22 @@
+import type { IncomingEvent } from '../domain/channel.js';
+import type { Session } from '../domain/session.js';
+
+export interface SessionFirstTouchInput {
+  readonly session: Session;
+  readonly event: IncomingEvent;
+}
+
+// Channel-agnostic session lifecycle hook invoked once per session inside
+// the JobRunner queue (off the inbound ack path). Returns synthetic events
+// the use case records as user turns BEFORE the live event's agent run.
+//
+// Implementations own their own "already done" flag — typically via
+// `session.metadata` — and reconcile single-process races via the
+// JobRunner per-key FIFO contract plus an in-impl fresh re-read
+// (`SessionStore.findByRef`) to defend against multi-process drift.
+//
+// Failure semantics: if `onFirstTouch` throws, the use case logs and still
+// processes the live event. Synthetic-event delivery is best-effort.
+export interface SessionFirstTouch {
+  onFirstTouch(input: SessionFirstTouchInput): Promise<readonly IncomingEvent[]>;
+}

--- a/packages/runtime/src/compose.ts
+++ b/packages/runtime/src/compose.ts
@@ -15,6 +15,7 @@ import type {
   Logger,
   McpServerConfig,
   OutboundChannel,
+  SessionFirstTouch,
   SessionPolicy,
   SessionStore,
   TenantId,
@@ -26,12 +27,16 @@ import type { Secrets } from './config/secrets.js';
 
 export interface BuildChannelsDeps {
   readonly sessionStore: SessionStore;
+  readonly logger: Logger;
 }
 
 export interface BuildChannelsResult {
   readonly inboundChannels?: readonly InboundChannel[];
   readonly outboundChannels?: ReadonlyMap<ChannelKind, OutboundChannel>;
   readonly sessionPolicies?: ReadonlyMap<ChannelKind, SessionPolicy>;
+  // Per-channel session-bootstrap hooks. Run inside the JobRunner queue
+  // (off the inbound ack path) on each session's first touch.
+  readonly sessionFirstTouches?: ReadonlyMap<ChannelKind, SessionFirstTouch>;
   // Per ARCHITECTURE.md §11.1 — channel-adapter MCP servers the runtime
   // forwards to the agent runner.
   readonly mcpServers?: readonly McpServerConfig[];
@@ -104,10 +109,11 @@ export async function compose(args: ComposeArgs): Promise<RuntimeHandles> {
     },
   });
 
-  const built = args.buildChannels ? await args.buildChannels({ sessionStore }) : undefined;
+  const built = args.buildChannels ? await args.buildChannels({ sessionStore, logger }) : undefined;
   const inboundChannels = built?.inboundChannels ?? args.inboundChannels ?? [];
   const outboundChannels = built?.outboundChannels ?? args.outboundChannels ?? new Map();
   const sessionPolicies = built?.sessionPolicies ?? args.sessionPolicies ?? new Map();
+  const sessionFirstTouches = built?.sessionFirstTouches;
   const mcpServers = built?.mcpServers ?? [];
 
   const agentRunner = new ClaudeCliAgentRunner({
@@ -122,6 +128,7 @@ export async function compose(args: ComposeArgs): Promise<RuntimeHandles> {
     jobRunner,
     sessionPolicies,
     outboundChannels,
+    ...(sessionFirstTouches !== undefined ? { sessionFirstTouches } : {}),
     resolveTenant: args.resolveTenant ?? (() => DEFAULT_TENANT),
     agentWorkdir: config.agentWorkdir,
     logger,

--- a/packages/testing/src/app/handle-incoming-message-first-touch.test.ts
+++ b/packages/testing/src/app/handle-incoming-message-first-touch.test.ts
@@ -2,6 +2,7 @@ import type {
   ChannelKind,
   HandleIncomingMessageDeps,
   IncomingEvent,
+  Logger,
   OutboundChannel,
   Session,
   SessionFirstTouch,
@@ -11,7 +12,7 @@ import type {
   TenantId,
 } from '@agentry/core';
 import { makeHandleIncomingMessage, SYNTHETIC_EVENT_METADATA_KEY } from '@agentry/core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { RecordingAgentRunner } from '../agent-runner/recording-agent-runner.js';
 import { RecordingOutboundChannel } from '../channels/recording-outbound-channel.js';
 import { InMemoryJobRunner } from '../job-runner/in-memory-job-runner.js';
@@ -173,12 +174,18 @@ describe('makeHandleIncomingMessage — sessionFirstTouch integration', () => {
     ]);
   });
 
-  it('proceeds with live event when onFirstTouch throws (failure is swallowed)', async () => {
+  it('proceeds with live event when onFirstTouch throws (failure is swallowed and warn-logged)', async () => {
     // Inline rewire — not worth threading a broken-impl override through buildHarness for one case.
     const broken: SessionFirstTouch = {
       onFirstTouch: async () => {
         throw new Error('backfill blew up');
       },
+    };
+    const warnSpy = vi.fn();
+    const recordingLogger: Logger = {
+      ...silentLogger,
+      warn: warnSpy,
+      child: () => recordingLogger,
     };
     const sessionStore = new InMemorySessionStore();
     const jobRunner = new InMemoryJobRunner();
@@ -194,7 +201,7 @@ describe('makeHandleIncomingMessage — sessionFirstTouch integration', () => {
       sessionFirstTouches: new Map([['test', broken]]),
       resolveTenant: () => 'tenant-1',
       agentWorkdir: '/tmp/agent-workdir',
-      logger: silentLogger,
+      logger: recordingLogger,
     });
 
     await handle(makeEvent('live-1', 'live mention'));
@@ -204,5 +211,10 @@ describe('makeHandleIncomingMessage — sessionFirstTouch integration', () => {
     const turns = await sessionStore.getRecentTurns(session.id, 100);
     expect(turns.map((t) => t.contentText)).toEqual(['live mention', 'reply']);
     expect(outbound.replies).toHaveLength(1);
+    // Regression guard: removing the catch's log.warn would silently
+    // hide first-touch failures.
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [calledWith] = warnSpy.mock.calls;
+    expect(calledWith?.[1]).toMatch(/first-touch failed/);
   });
 });

--- a/packages/testing/src/app/handle-incoming-message-first-touch.test.ts
+++ b/packages/testing/src/app/handle-incoming-message-first-touch.test.ts
@@ -1,0 +1,208 @@
+import type {
+  ChannelKind,
+  HandleIncomingMessageDeps,
+  IncomingEvent,
+  OutboundChannel,
+  Session,
+  SessionFirstTouch,
+  SessionFirstTouchInput,
+  SessionPolicy,
+  SessionStore,
+  TenantId,
+} from '@agentry/core';
+import { makeHandleIncomingMessage, SYNTHETIC_EVENT_METADATA_KEY } from '@agentry/core';
+import { describe, expect, it } from 'vitest';
+import { RecordingAgentRunner } from '../agent-runner/recording-agent-runner.js';
+import { RecordingOutboundChannel } from '../channels/recording-outbound-channel.js';
+import { InMemoryJobRunner } from '../job-runner/in-memory-job-runner.js';
+import { InMemoryKnowledgeStore } from '../knowledge-store/in-memory-knowledge-store.js';
+import { silentLogger } from '../logger/silent-logger.js';
+import { StaticSessionPolicy } from '../session-policy/static-session-policy.js';
+import { InMemorySessionStore } from '../session-store/in-memory-session-store.js';
+import { type Deferred, deferred } from '../test-utils/deferred.js';
+
+const BACKFILLED_KEY = 'backfilled';
+
+function makeEvent(idempotencyKey: string, text: string): IncomingEvent {
+  return {
+    channelKind: 'test',
+    channelNativeRef: 'thread-1',
+    author: { channelUserId: 'u1' },
+    payload: { text },
+    threading: {},
+    receivedAt: new Date(),
+    idempotencyKey,
+  };
+}
+
+function makeAgentRunner(): RecordingAgentRunner {
+  return new RecordingAgentRunner([
+    { type: 'text_delta', text: 'reply' },
+    { type: 'finished', reason: 'complete', usage: { input: 0, output: 0 } },
+  ]);
+}
+
+// Test-only first-touch impl that mirrors the production contract:
+// closure-snapshot check → fresh re-read via SessionStore → "slow path"
+// (counted) only when both say not-yet-done. Slow path can be paused via
+// `slowPathGate` to model an in-flight backfill.
+class TestFirstTouch implements SessionFirstTouch {
+  slowPathCalls = 0;
+  slowPathGate: Deferred<void> | null = null;
+  constructor(
+    private readonly store: SessionStore,
+    private readonly policy: SessionPolicy,
+  ) {}
+
+  async onFirstTouch(input: SessionFirstTouchInput): Promise<readonly IncomingEvent[]> {
+    const { session, event } = input;
+    if (session.metadata[BACKFILLED_KEY] === true) return [];
+    const fresh = await this.store.findByRef(
+      this.policy.channelKind,
+      this.policy.computeNativeRef(event),
+      session.tenantId,
+    );
+    if (fresh !== null && fresh.metadata[BACKFILLED_KEY] === true) return [];
+
+    this.slowPathCalls += 1;
+    if (this.slowPathGate !== null) await this.slowPathGate.promise;
+
+    await this.store.setMetadata(session.id, { [BACKFILLED_KEY]: true });
+    return [
+      {
+        channelKind: 'test',
+        channelNativeRef: event.channelNativeRef,
+        author: { channelUserId: 'past-user' },
+        payload: { text: 'past msg' },
+        threading: {},
+        receivedAt: new Date(),
+        idempotencyKey: `synth-${event.idempotencyKey}`,
+        metadata: { [SYNTHETIC_EVENT_METADATA_KEY]: true },
+      },
+    ];
+  }
+}
+
+interface RaceHarness {
+  readonly handle: ReturnType<typeof makeHandleIncomingMessage>;
+  readonly sessionStore: InMemorySessionStore;
+  readonly jobRunner: InMemoryJobRunner;
+  readonly outbound: RecordingOutboundChannel;
+  readonly firstTouch: TestFirstTouch;
+}
+
+function buildHarness(): RaceHarness {
+  const sessionStore = new InMemorySessionStore();
+  const knowledgeStore = new InMemoryKnowledgeStore();
+  const jobRunner = new InMemoryJobRunner();
+  const outbound = new RecordingOutboundChannel('test');
+  const policy = new StaticSessionPolicy({ channelKind: 'test' });
+  const firstTouch = new TestFirstTouch(sessionStore, policy);
+
+  const deps: HandleIncomingMessageDeps = {
+    sessionStore,
+    knowledgeStore,
+    agentRunner: makeAgentRunner(),
+    jobRunner,
+    sessionPolicies: new Map<ChannelKind, SessionPolicy>([['test', policy]]),
+    outboundChannels: new Map<ChannelKind, OutboundChannel>([['test', outbound]]),
+    sessionFirstTouches: new Map<ChannelKind, SessionFirstTouch>([['test', firstTouch]]),
+    resolveTenant: () => 'tenant-1' as TenantId,
+    agentWorkdir: '/tmp/agent-workdir',
+    logger: silentLogger,
+  };
+
+  return {
+    handle: makeHandleIncomingMessage(deps),
+    sessionStore,
+    jobRunner,
+    outbound,
+    firstTouch,
+  };
+}
+
+describe('makeHandleIncomingMessage — sessionFirstTouch integration', () => {
+  it('runs onFirstTouch before processOneTurn and records synthetic + live turns', async () => {
+    const h = buildHarness();
+    await h.handle(makeEvent('live-1', 'live mention'));
+    await h.jobRunner.drain();
+
+    const session = await h.sessionStore.findOrCreate('test', 'thread-1', 'tenant-1');
+    const turns = await h.sessionStore.getRecentTurns(session.id, 100);
+
+    expect(h.firstTouch.slowPathCalls).toBe(1);
+    expect(turns.map((t) => t.contentText)).toEqual(['past msg', 'live mention', 'reply']);
+    expect(h.outbound.replies.map((r) => r.content.text)).toEqual(['reply']);
+  });
+
+  it('JobRunner per-key FIFO ensures synthetics are not double-fetched across queued mentions', async () => {
+    const h = buildHarness();
+    h.firstTouch.slowPathGate = deferred<void>();
+
+    // Mention 1 enqueues; its job starts and pauses inside onFirstTouch.
+    await h.handle(makeEvent('live-1', 'first'));
+    // Yield so the queued job actually starts and hits the gate.
+    await new Promise<void>((r) => setImmediate(r));
+    expect(h.firstTouch.slowPathCalls).toBe(1);
+
+    // Mention 2 enqueues while mention 1 is paused. Use case captures a
+    // session snapshot whose metadata still lacks `backfilled` (mention 1
+    // hasn't reached setMetadata yet). The captured snapshot is the
+    // "stale closure" the impl must re-confirm via findByRef.
+    await h.handle(makeEvent('live-2', 'second'));
+
+    // Release mention 1: it sets metadata[backfilled]=true and returns
+    // synthetic, then live processing runs. Mention 2's job runs next:
+    // its closure snapshot says false but findByRef now says true →
+    // returns [] without entering the slow path.
+    h.firstTouch.slowPathGate.resolve();
+    await h.jobRunner.drain();
+
+    expect(h.firstTouch.slowPathCalls).toBe(1);
+
+    const session = await h.sessionStore.findOrCreate('test', 'thread-1', 'tenant-1');
+    const turns = await h.sessionStore.getRecentTurns(session.id, 100);
+    // Mention 1: synthetic + live + agent. Mention 2: live + agent only
+    // (no synthetic because first-touch returned []).
+    expect(turns.map((t) => t.contentText)).toEqual([
+      'past msg',
+      'first',
+      'reply',
+      'second',
+      'reply',
+    ]);
+  });
+
+  it('proceeds with live event when onFirstTouch throws (failure is swallowed)', async () => {
+    // Inline rewire — not worth threading a broken-impl override through buildHarness for one case.
+    const broken: SessionFirstTouch = {
+      onFirstTouch: async () => {
+        throw new Error('backfill blew up');
+      },
+    };
+    const sessionStore = new InMemorySessionStore();
+    const jobRunner = new InMemoryJobRunner();
+    const outbound = new RecordingOutboundChannel('test');
+    const policy = new StaticSessionPolicy({ channelKind: 'test' });
+    const handle = makeHandleIncomingMessage({
+      sessionStore,
+      knowledgeStore: new InMemoryKnowledgeStore(),
+      agentRunner: makeAgentRunner(),
+      jobRunner,
+      sessionPolicies: new Map([['test', policy]]),
+      outboundChannels: new Map([['test', outbound]]),
+      sessionFirstTouches: new Map([['test', broken]]),
+      resolveTenant: () => 'tenant-1',
+      agentWorkdir: '/tmp/agent-workdir',
+      logger: silentLogger,
+    });
+
+    await handle(makeEvent('live-1', 'live mention'));
+    await jobRunner.drain();
+
+    const session: Session = await sessionStore.findOrCreate('test', 'thread-1', 'tenant-1');
+    const turns = await sessionStore.getRecentTurns(session.id, 100);
+    expect(turns.map((t) => t.contentText)).toEqual(['live mention', 'reply']);
+    expect(outbound.replies).toHaveLength(1);
+  });
+});

--- a/packages/testing/src/app/handle-incoming-message.test.ts
+++ b/packages/testing/src/app/handle-incoming-message.test.ts
@@ -17,18 +17,7 @@ import { InMemoryKnowledgeStore } from '../knowledge-store/in-memory-knowledge-s
 import { silentLogger } from '../logger/silent-logger.js';
 import { StaticSessionPolicy } from '../session-policy/static-session-policy.js';
 import { InMemorySessionStore } from '../session-store/in-memory-session-store.js';
-
-interface Deferred<T> {
-  readonly promise: Promise<T>;
-  resolve: (value: T) => void;
-}
-function deferred<T>(): Deferred<T> {
-  let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
-    resolve = res;
-  });
-  return { promise, resolve };
-}
+import { deferred } from '../test-utils/deferred.js';
 
 function makeEvent(overrides: Partial<IncomingEvent> = {}): IncomingEvent {
   return {

--- a/packages/testing/src/test-utils/deferred.ts
+++ b/packages/testing/src/test-utils/deferred.ts
@@ -1,0 +1,12 @@
+export interface Deferred<T> {
+  readonly promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+export function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}


### PR DESCRIPTION
## Summary

- New `SessionFirstTouch` port in `packages/core` — channel-agnostic session-bootstrap hook invoked inside the `JobRunner` queue (off the inbound ack path)
- `SlackHistoryBackfiller` rewritten as a `SessionFirstTouch` impl: drops own `inFlight` Map + own `findOrCreate`. Closure-snapshot check on `session.metadata.slackBackfilled` → `findByRef` race re-check (PR A's port) → cold path
- `SlackInboundChannel` simplified: `app_mention` handler does only `mapAppMentionToIncomingEvent` + `await handler(live)`; `backfiller`/`resolveTenant` options removed
- Failure-swallow contract preserved at the use case (`try/catch` around `onFirstTouch` + `log.warn`); regression-guard test added
- ARCHITECTURE.md §4.9 added; §5.1 HandleIncomingMessage flow updated

## Why

Closes the structural ack-path block #63. Previously `SlackInboundChannel.app_mention` awaited `SlackHistoryBackfiller.backfillIfNeeded` BEFORE forwarding the live event, synchronously holding Slack's 3-second ack budget on `findOrCreate` + `conversations.replies` + `setMetadata` + N→IncomingEvent maps. After this PR: ack returns fast, backfill runs as the first step of the queued job, and concurrency consolidates to a single primitive (JobRunner per-key FIFO).

## Live e2e (verified pre-PR)

3-mention test against real Slack workspace + Postgres+pgvector + Claude CLI. All acceptance criteria from #63 met:

| # | thread | first-touch log | timing |
|---|---|---|---|
| 1 | `slack:C0B2EKGCXNW:…` (new) | `slack first-touch: backfilled N messages from conversations.replies` (synthetics: 0) | enqueueing → first-touch 378ms |
| 2 | same as #1 | `slack first-touch: skipped (already backfilled)` | enqueueing → first-touch **6ms** (DB read + closure check, **0 Slack API calls**) |
| 3 | `slack:C0ARSEED0S2:…` (different) | `slack first-touch: backfilled N messages from conversations.replies` (synthetics: 0) | cold path reproduces |

Replies posted on all 3. Health endpoint OK. No errors in server log.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` 0 errors / 0 warnings (6 pre-existing `useLiteralKeys` infos in unrelated files predate this branch — see commit ae9b6412)
- [x] `pnpm test` — 223 passed (5 skipped pre-existing)
- [x] `pnpm depcheck` — no dependency violations
- [x] Race test in `packages/testing/src/app/handle-incoming-message-first-touch.test.ts` — verifies JobRunner per-key FIFO + closure-vs-`findByRef` defense-in-depth contract
- [x] Failure-swallow regression-guard test — asserts `log.warn` fires when `onFirstTouch` throws
- [x] Live e2e: 3 mentions / 2 threads (see table above)

## Depends on

#64 (PR #70, merged 2026-05-04) — provides `SessionStore.findByRef` used inside `onFirstTouch` for the multi-process race re-check.

## Out of scope (followups, file when a driver appears)

- Bulk `recordTurn` insert for >100-msg threads (still N sequential roundtrips, just relocated; pre-existing behavior)
- Multi-process firstTouch race beyond `findByRef` re-check (single-process MVP-acceptable)
- Promote `noopLogger` to `@agentry/core` to dedupe with `silentLogger` in testing + 2 adapter test files (depcruiser bars adapter→testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)