### PR TITLE
docs(phase-4): extension guides + README/CHANGELOG/CONTRIBUTING/FOR_ONBOARDING (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it leaves pre-1.0. Until then, every published change is breaking by default.
+
+## [Unreleased] — Phase 4
+
+### Added
+- Extension guides for channel adapters, agent runners, embedding providers, and store adapters (`docs/extending/*`).
+- README quick-start with one-table env-var reference and links to every extension guide.
+- `CHANGELOG.md` and `CONTRIBUTING.md`; `FOR_ONBOARDING.md` for the codebase tour.
+
+### Changed
+- `docs/extending/configuration.md` answers the previously open question on adapter-specific secrets — centralized `SecretsSchema` in `runtime` is the chosen pattern; adapters take plain values via constructor.
+
+## Phase 3 — MVP slice (2026-04 → 2026-05)
+
+The first end-to-end vertical slice. After this milestone a developer can fork, configure, and run a Slack bot answering with Claude, with both turns persisted in pgvector.
+
+### Added
+- **Slack channel adapter** (`@agentry/adapter-channel-slack`) with `slack-bolt` 4. `app_mention` events become `IncomingEvent`s; threads become sessions keyed by `slack:${channel}:${thread_ts}`. Single shared `WebClient` across outbound + history backfill.
+- **Slack OAuth scope verification at startup** — fails fast on misconfig instead of surfacing a runtime `missing_scope` 24 hours later. Required scopes: `app_mentions:read`, `chat:write`, `channels:history`, `groups:history`, `channels:read`, `groups:read`, `users:read`. Manifest changes require app reinstall.
+- **Slack thread history backfill** that records prior thread messages as synthetic user turns on a session's first contact. Bot's own past replies are filtered (`bot_id` exclusion) so they don't get recorded as user turns. The backfill runs **off the inbound ack path** — see *Changed* below.
+- **Claude CLI subprocess runner** (`@agentry/adapter-runner-claude-cli`) — streams NDJSON events (`text_delta`, `tool_call`, `tool_result`, `finished`, `error`). Honors `--resume <session-id>` for KV-cache continuity across turns. Supports `--mcp-config` forwarding from channel adapters.
+- **MCP servers from channel adapters** — `BuildChannelsResult.mcpServers` is plumbed into the runner, materialized as a process-private tempfile (mode 0600 under `os.tmpdir()`, never written to `seed/agent-workdir/`). Cleanup on `exit`, `SIGINT`, AND `SIGTERM`.
+- **Slack MCP tools** for the agent: `slack_get_channel_history` (preserves `bot_id` so the agent can read workflow-bot reports), `slack_get_user_info` (resolves `U…` IDs to display names).
+- **`agentry-slack` CLI** — `verify-scopes`, `list-channels`, `send-test-message --channel <id> [--text <msg>] [--thread-ts <ts>]`.
+- **Channel context header in the agent prompt** — when a channel's `SessionPolicy` returns `toAgentContext(event)`, the framework prepends a `[Channel context]` block (e.g., `channelId: C123`, `threadTs: 1234.5678`). Lets the agent call `slack_get_channel_history(channelId)` without the user spelling out the ID.
+- **Postgres + pgvector schema migrations** (`@agentry/adapter-store-pgvector`). `agentry migrate` CLI applies them idempotently; `_agentry_migrations` table records applied filenames.
+- **`PgvectorSessionStore`** with `findOrCreate`, `findByRef` (read-only counterpart, no UPSERT side effect), `setMetadata` (shallow JSONB merge), `recordTurn` (per-session monotonic `seq_no`), `listSessionsForDistillation`.
+- **`PgvectorKnowledgeStore`** with `recordSource`, `upsertItem` (dedup by `(tenant_id, external_id)` + canonical hash for distilled items), `retrieve` (semantic mode with cosine), `listByTenant` (server-side cursor stream).
+- **`VoyageEmbeddingProvider`** — `voyage-3.5` (1024-dim) by default. Batch up to 128 inputs per request; retry-after honored with a 30s cap.
+- **In-memory `JobRunner`** with per-key FIFO chains. Same `key` (typically `sessionId`) → strict FIFO; different keys → parallel. `drain()` for graceful shutdown.
+- **`SessionFirstTouch` port** for channel-agnostic session-bootstrap work (Slack history backfill is the reference impl). Runs inside the `JobRunner` queue, off the inbound ack path. Failure is swallowed (logged) so a transient backfill error doesn't drop the live mention.
+- **`SessionStore.findByRef`** — read-only counterpart of `findOrCreate` for hot-path checks.
+- **Env-shadow detection** — `apps/server` fail-fasts at boot if a shell-exported env var shadows a `.env` value. Lists offending keys (no values; token-shape leak guard). Skipped silently when no `.env` file exists.
+- **`SecretsSchema` validation** at startup with key-by-key error messages. Bad values are not echoed back in errors.
+- **Logger port** + `PinoLogger` adapter with structured JSON output.
+- **`docker-compose.yml`** (dev-only) shipping pgvector/pgvector:pg16.
+- **Smoke-test recipe** at `docs/recipes/smoke-test.md` — fresh checkout to working bot in ~30 minutes.
+
+### Changed
+- **Slack history backfill moved off the ack path.** Previously `SlackInboundChannel.app_mention` awaited backfill BEFORE forwarding the live event, blocking Slack's 3-second ack budget on `findOrCreate` + `conversations.replies` + `setMetadata`. Now: `app_mention` does only `mapAppMentionToIncomingEvent` + `await handler(live)`. Backfill runs as the first step of the queued job. **Hot path** (already-backfilled session) returns in **6ms** with zero Slack API calls; cold path stays at ~378ms for the one-time fetch.
+- **Concurrency consolidated to JobRunner per-key FIFO.** The Slack backfiller no longer carries its own `inFlight` Map; single-process dedup is the queue contract, multi-process drift is reconciled via `findByRef` re-read inside the impl.
+- **`agentry-slack` CLI signature unified** to options-object instead of positional args (each command takes `{token, …}`).
+- **Bot replies hardened** — `seed/agent-workdir/CLAUDE.md` now requires the agent to resolve `U…` IDs to display names before replying. Live test confirms `송낙훈 (nakhun.song)` instead of `U044K34GBLP`.
+- **Apps boundary relaxed** to allow `apps/cli` and `apps/server` to import adapters directly (composition root role per ARCHITECTURE.md §7). `runtime` is convenience, not a chokepoint.
+
+### Fixed
+- **`ClaudeCliAgentRunner` SIGTERM tempfile leak** — `process.once('exit')` does not fire on signal-kill. Added explicit `SIGINT` and `SIGTERM` cleanup hooks. Live `kill -TERM <pid>` test confirms tempfile is unlinked. Documented the default-fatal-suppression caveat for embedders relying on Node's terminate-on-signal default.
+- **Recipe bugs caught during real e2e** — redundant `pnpm install/build` inside the migrate step; missing `-T` on `docker compose exec` heredoc invocations.
+
+### Removed
+- `SlackInboundChannel.backfiller` and `SlackInboundChannel.resolveTenant` options — backfill is now `SessionFirstTouch`-driven, tenant resolution is the use case's responsibility.
+- `SlackHistoryBackfiller.backfillIfNeeded` and the in-memory `inFlight` Map. Replaced by `SlackHistoryBackfiller.onFirstTouch({session, event})`.
+
+## Phase 2 — KnowledgeStore design (2026-04)
+
+### Added
+- `docs/design/knowledge-store.md` — three-layer memory model (relational + vector + graph), Extract → Cognify → Load pipeline, distillation triggers (idle / explicit / scheduled / rolling), per-source canonical hashing for dedup.
+
+## Phase 1 — Architecture (2026-03 → 2026-04)
+
+### Added
+- `ARCHITECTURE.md` — ports & adapters layout, directory boundaries, composition root pattern, MCP exposure model.
+- Monorepo bootstrap: pnpm workspaces, TypeScript 6 strict + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` + `verbatimModuleSyntax`, ESM only, `tsc --build` with project references, vitest 4, Biome 2 single-tool lint+format, dependency-cruiser 17 layer-rule enforcement.
+- Core ports: `InboundChannel`, `OutboundChannel`, `SessionPolicy`, `SessionStore`, `KnowledgeStore`, `AgentRunner`, `JobRunner`, `EmbeddingProvider`, `Logger`, `McpServerConfig`.
+- Domain types in `packages/core/src/domain/` — `IncomingEvent`, `Session`, `Turn`, `KnowledgeItem`, `RetrievalQuery`, etc.
+- `HandleIncomingMessage` use case wiring all the above.
+- `AgentryConfig` (zod) + `SecretsSchema` (zod) — Phase 3-validated tier separation.
+- `@agentry/testing` package with in-memory adapters for use-case tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,125 @@
+# Contributing
+
+agentry is fork-friendly by design. You're expected to fork, customize, and deploy — not install from npm and configure via CLI flags. This guide covers two flows:
+
+1. **Keeping your fork in sync** with upstream framework updates without losing your customizations.
+2. **Upstreaming improvements** back to the framework.
+
+## The fork model
+
+```
+upstream (NakhunSong/agentry)
+   │
+   │ framework code, ports, adapters, default seed
+   │ pushed downstream via fast-forward merge
+   ▼
+your fork (you/agentry-mybot)
+   │
+   │ your channel config, agent-workdir/CLAUDE.md, your .env, your DB
+   │ stays in your fork; never touched by upstream
+   ▼
+deploy (VPS, container, etc.)
+```
+
+Two layers, conceptually:
+
+| Layer | Examples | Owner |
+|---|---|---|
+| **Framework** | `packages/core`, `packages/adapter-*`, `packages/runtime`, `apps/*`, default `seed/agent-workdir/CLAUDE.md`, `docs/`, `ARCHITECTURE.md`, root configs | Upstream — pull updates without thinking |
+| **Your data** | `.env`, your customizations of `seed/agent-workdir/`, anything in `data/` your bot writes, Postgres content | Your fork — upstream never touches |
+
+The split exists in code: `seed/agent-workdir/` is procedural memory (instructions, skills, rules) and ships shared. Episodic + semantic memory lives in your Postgres database, which the framework manages but never serializes into git.
+
+## Keeping your fork in sync
+
+```bash
+# One-time setup: add upstream
+git remote add upstream https://github.com/NakhunSong/agentry.git
+
+# Each time you want updates
+git fetch upstream
+git checkout main
+git merge upstream/main
+```
+
+**Safe to fast-forward**: framework code, default rules, docs, configs (`tsconfig.json`, `package.json`, `biome.json`, `.dependency-cruiser.cjs`).
+
+**Will conflict on customization** (resolve manually):
+
+- `seed/agent-workdir/CLAUDE.md` — if you replaced the default with your bot's persona, reconcile manually. The recommended pattern is to keep the framework default and overlay your additions in a separate file your CLAUDE.md references via `@./my-overlay.md`.
+- `.env.example` — adopt new keys as upstream adds them; your `.env` (gitignored) stays.
+- `apps/server/src/main.ts` — if you've extended `buildChannels` for your own adapter, re-apply the change after the merge. Keep your adapter in `packages/adapter-channel-mybot/` so the diff is cleaner.
+
+**Never touched by upstream**: anything outside the framework layer above. Your `.env` is gitignored. Your DB is in a Postgres container or external service. Your branch-specific customizations live in branches you control.
+
+## Upstreaming improvements
+
+Bugs, port-contract clarifications, new adapters that other forks would want, doc fixes — open a PR upstream.
+
+### Before opening a PR
+
+Run the full local pipeline:
+
+```bash
+pnpm typecheck    # tsc --build
+pnpm lint         # biome check
+pnpm test         # vitest run (workspace mode)
+pnpm depcheck     # dependency-cruiser layer enforcement
+```
+
+All must pass cleanly. The depcheck is non-negotiable — boundary violations block the merge.
+
+### What lands easily
+
+- New port or adapter following the patterns in `docs/extending/*` (channel, runner, embedding, store).
+- Bug fixes with a regression test (vitest) reproducing the failure.
+- Doc improvements, especially worked examples in `docs/extending/*`.
+- Smoke-test recipe additions (`docs/recipes/`) — alternative deployment patterns, e.g., Kubernetes, Fly.io.
+
+### What needs design discussion first (open an issue)
+
+- Changes to a port signature in `@agentry/core`. Every adapter and every fork's overrides depend on stability here.
+- Adding a port. Each new port is a new contract every adapter author has to implement or opt out of.
+- Architectural shifts (e.g., promoting `seed/agent-workdir/` into a separate package). Easier to land after consensus than to re-do.
+
+### Commit and PR conventions
+
+Commit message format: `<type>(<scope>): <description>`. Examples from history:
+
+```
+feat(core,slack,runtime,server,testing): SessionFirstTouch port + Slack ack-path purification (#63)
+fix(runner): SIGTERM tempfile cleanup
+docs(extending): channel-adapter guide
+```
+
+Scopes are package or area names: `core`, `slack`, `runtime`, `server`, `pgvector`, `testing`, `docs`, `ci`, etc. Multiple comma-separated when a change spans them.
+
+PR descriptions should include:
+
+- **Summary** (1–3 bullets) — what changed.
+- **Why** — what driver/issue motivated it.
+- **Test plan** — checked boxes for typecheck/lint/test/depcheck plus any live e2e if relevant.
+- **Out of scope** — followups intentionally deferred. File new issues for them when a driver appears (don't park them on the PR).
+
+## Workflow conventions
+
+- **One PR per logical change.** Refactors, port lifts, and feature work go in separate PRs even when the diff feels related. Reviewers can hold one model in their head at a time.
+- **Squash merge only inside worktrees.** Top-level feature → main merges use regular merge (`--merge`), not squash. Branch deletion is manual, not automated at merge time.
+- **No `--no-verify` / `--no-gpg-sign`** unless there's a documented reason. Hooks exist to catch things; bypassing them in code that lands in main is an antipattern.
+- **Update CHANGELOG.md** under `## [Unreleased]` for any user-visible change. Internal refactors don't need an entry.
+- **Update relevant docs** in the same PR — `ARCHITECTURE.md` for new ports, `docs/extending/*` for guide-relevant changes, `README.md` for env-var or quick-start changes.
+
+## Code style
+
+- TypeScript strict + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` + `verbatimModuleSyntax`. The compiler catches most issues; biome catches the rest.
+- ESM only. Imports in source use `.js` extensions even though the file is `.ts` (TypeScript respects literal paths under `NodeNext`).
+- `import type { Foo }` for type-only imports. Mixing values and types in one import causes build errors.
+- No `any`. Define proper types at every boundary.
+- No backwards-compatibility shims. Update call sites directly.
+- Comments should explain WHY, not WHAT. Well-named identifiers handle the WHAT.
+
+See `CLAUDE.md` for the full convention list and `~/.claude/rules/` for the workflow rules the maintainer follows.
+
+## License
+
+MIT — see [LICENSE](./LICENSE). Contributions are accepted under the same license.

--- a/FOR_ONBOARDING.md
+++ b/FOR_ONBOARDING.md
@@ -1,0 +1,139 @@
+# For onboarding
+
+A guided tour for developers (or AI agents) joining the agentry codebase. This is the "what's actually going on here, and why" companion to [`ARCHITECTURE.md`](./ARCHITECTURE.md), which is the formal design document.
+
+If you read only one section: **Read "The hexagon and its tax"** below. Everything else flows from that decision.
+
+## Twenty-thousand-foot view
+
+agentry is a framework for building **personal Claude bots**. Not a SaaS, not a hosted product — a fork-friendly skeleton you clone, customize, and run on your own VPS. Today the bot lives in Slack; tomorrow it lives wherever you teach it to listen. The framework's job is everything *between* "a message arrived somewhere" and "the agent replied with relevant context": session bootstrap, memory persistence, retrieval, prompt assembly, runner orchestration, and reply delivery.
+
+The shipped MVP slice (Phase 3): post a Slack mention, get a Claude reply, both turns persist in pgvector, and the next mention gets context-aware retrieval. That's what's running.
+
+## The hexagon and its tax
+
+The single most important architectural decision: **agentry is a hexagonal (ports & adapters) codebase**. The domain core lives in `packages/core` and knows nothing — *literally nothing* — about Slack, Postgres, Anthropic, or anything else outside its own type universe. Concrete services plug in via "ports" (TypeScript interfaces) implemented by "adapters" (concrete classes).
+
+The benefit: when GPT-5 ships, swapping the agent runner is a constructor change. When Discord becomes a priority, the channel adapter is a new package — no other code knows the difference. When you decide pgvector isn't enough, you write `QdrantKnowledgeStore` against the same port and the use cases never notice.
+
+The tax: **`packages/core` cannot import anything else in the workspace**. Not a util from `runtime`, not a fake from `testing`, nothing. `dependency-cruiser` enforces this in CI. Adapters can only import from `core`; testing can only import from `core`; runtime can import core + adapters. Apps can do anything because they're the composition root.
+
+This sounds tidy on paper. In practice it means you'll occasionally find yourself duplicating a tiny utility (a `silentLogger`, a `Deferred<T>`) in multiple places because the canonical home is forbidden by the boundary rules. The right reaction is **don't fight depcruiser** — file a "promote to core when there are 3+ drivers" followup and move on. The first three times the rule felt annoying; the first time someone tried to import a `pg` Pool into `core` and depcruiser said no, the rule paid for itself forever.
+
+## Three kinds of memory
+
+Conceptually, agentry distinguishes three memory layers (per Cognee's Extract → Cognify → Load pattern):
+
+1. **Episodic** — raw turns. Every user message and agent reply, verbatim. Lives in Postgres `turns` table. Source of truth for "what was actually said." A 30-message thread is 30 rows.
+2. **Semantic** — distilled `KnowledgeItem`s. Phase 2+ pipeline consumes recent turns and produces durable facts ("the user prefers TS over JS"; "the customer's account ID is X"). Stored in pgvector. Retrieved by similarity per turn.
+3. **Procedural** — the agent's own instructions. Today this is just `seed/agent-workdir/CLAUDE.md`. As your fork grows, you'll add `seed/agent-workdir/.claude/skills/` and `seed/agent-workdir/.claude/rules/` — the Claude CLI subprocess inherits whatever you put there the same way *you* inherit `~/.claude/CLAUDE.md` when you run Claude Code.
+
+The three live in different storage tiers (DB, DB, git). Distinguishing them matters because **upstream framework updates push procedural changes downstream to forks, but never touch episodic or semantic data**. That's the "single-direction sync" promise: when you `git pull upstream main`, you get the latest framework code and the latest default `CLAUDE.md`, but your bot doesn't forget who its users are.
+
+## The 3-second ack budget story
+
+This is the single most pedagogically useful incident in the codebase. If you're going to extend a channel adapter, internalize this story.
+
+**Setup**: Slack's Events API requires the bot to acknowledge a webhook within 3 seconds. Miss the budget and Slack assumes you're dead, redelivers the event, and your bot processes it twice. The framework's `HandleIncomingMessage` use case is designed around this — `findOrCreate(session)` (one DB roundtrip) + `JobRunner.enqueue(job)` (no I/O), then return. The agent's actual run happens inside the queued job, which can take 30 seconds or more.
+
+**The trap**: when shipping #18 (Slack adapter), the obvious place to do thread-history backfill was inside the `app_mention` handler — fetch `conversations.replies(thread_ts)`, map to synthetic events, forward them through the handler before the live event. It worked! The bot saw the full thread context. Then someone mentioned the bot in a thread with 40 prior messages, the backfill took 1.5 seconds, the agent run started normally, and Slack hit the 3-second timeout (because ack happens at *return-from-handler*, not at *first I/O*). Slack redelivered. The bot replied twice.
+
+**The fix wasn't a `Promise.race`** that would have shipped a week earlier. The structural fix was to define a new port — `SessionFirstTouch` — that runs *inside the queued job*, off the ack path entirely. Now `app_mention` does only `mapAppMentionToIncomingEvent` + `await handler(live)`; backfill is the first step of the queued job, and the framework swallows backfill failures so a transient Slack rate-limit can't drop the user's mention.
+
+**The measured payoff**: hot path (already-backfilled session) returns in **6ms** with zero Slack API calls. Cold path stays at ~378ms (one `conversations.replies`). And the architecture is now channel-agnostic — Discord's eventual `DiscordHistoryBackfiller` plugs into the same port.
+
+The lesson, made concrete: **structural fixes beat timing prayers**. Whenever you find yourself reaching for `Promise.race`, `setTimeout`, or "let's just make it faster," ask if the work belongs on the path you're trying to speed up. Often it doesn't.
+
+## Concurrency in 2 layers
+
+Two concurrency primitives, no more:
+
+1. **Process-level**: `JobRunner` per-key FIFO. Same `key` (typically `sessionId`) → strict FIFO chain; different keys → parallel. Implemented in-memory as a `Map<string, Promise<void>>` of last-promise-per-key. When you enqueue, you `previous.then(() => job)` and store the new tail.
+2. **Cross-process**: nothing yet. The MVP runs on a single VPS, single process. The architecture earmarks `pg-boss` as the production swap (issue #28) when horizontal scaling, restart durability, or operational visibility becomes a need. Until then, in-memory wins on simplicity.
+
+This is intentional minimalism. BullMQ + Redis would have been the "responsible enterprise" choice, but it would have added a container, an operational surface, and a serialization boundary — for a single-VPS bot that doesn't need any of those. The right time to add the queue is when the cost of *not* having it actually appears.
+
+The per-key FIFO contract is load-bearing for `SessionFirstTouch` correctness — see the inline comment in `packages/core/src/app/handle-incoming-message.ts`. Don't break it without understanding what depends on it.
+
+## The closure check + findByRef choreography
+
+When two mentions arrive in the same Slack thread within milliseconds, the use case enqueues two jobs with the same `key`. The first job's `SessionFirstTouch` runs, fetches history, sets `session.metadata.slackBackfilled = true`. The second job's `SessionFirstTouch` should see "already done" and skip the Slack API.
+
+Per-key FIFO makes single-process correctness trivial — job 2 can't start until job 1 finishes. But what if job 2 was enqueued by `handleIncomingMessage` while job 1 was running? The closure-captured `session` in job 2 still has `metadata.slackBackfilled` undefined (the framework called `findOrCreate` before enqueue, when the flag wasn't set yet). The closure is stale.
+
+Two layers of defense:
+
+1. **Closure check** (cheap): `if (session.metadata[SLACK_BACKFILLED_METADATA_KEY] === true) return [];`. When the flag was already true at `findOrCreate` time (i.e., a third mention after the second already finished), you skip without any I/O.
+2. **`findByRef` re-check** (one DB roundtrip): when the closure says "not done," re-read fresh. If a sibling has flipped the flag in the meantime, return `[]` without `setMetadata` and without the Slack API call.
+
+The race test in `packages/testing/src/app/handle-incoming-message-first-touch.test.ts` exercises exactly this — pause job 1's first-touch, enqueue mention 2, release job 1, drain queue, assert "slow path" called exactly once. The race is genuinely impossible to single-process-race when you understand the FIFO + closure interaction; the `findByRef` is **multi-process insurance** for the day a `pg-boss` adapter ships.
+
+## The PR decomposition style
+
+You'll notice the git history is full of small PRs. PR #70 lifted a `SessionStore.findByRef` port. PR #71 used that port to architecturally relocate Slack backfill. Combined into one PR they would have been 800+ lines of mixed concerns; split into two, each had one architectural decision and a tight reviewer-loop.
+
+The pattern: **port lift first**, **adapter integration second**. Lifting a port is a "shape" change reviewers can think about in isolation (does the contract make sense? is the input shape minimal?). Adapter integration is a "use" change (does this honor the contract? are the failure semantics right?). Doing them in one PR forces reviewers to evaluate both at once with no clear hand-off.
+
+The exception: when a change is genuinely small (< 200 lines) or when the port and the adapter are co-evolving and splitting would require throwaway scaffolding. Use judgment.
+
+## Recipes catch what tests can't
+
+The smoke-test recipe (`docs/recipes/smoke-test.md`) is the single most underrated artifact in the repo. Every Phase 3 PR ran the recipe live before merge — and every Phase 3 PR caught at least one bug that unit tests had missed. Some examples:
+
+- **`docker compose exec` heredoc** needs `-T` to skip TTY allocation, or the `<<'SQL'` blob gets mangled. Tests don't run docker; the recipe author hit it on attempt #2.
+- **`node --env-file=.env`** does *not* override variables already exported in the parent shell. Tests don't simulate shell exports; the recipe author hit a 30-minute "why isn't my new SLACK_BOT_TOKEN being read" before noticing the old one was still in the shell. Fixed by adding env-shadow detection at boot (`apps/server/src/env-shadow-check.ts`).
+- **Slack manifest reinstall** is required after every scope addition. The first time `SLACK_REQUIRED_SCOPES` grew (`channels:history`, `groups:history` for thread reads), the bot kept saying "missing required scopes" until the operator reinstalled the app. Documented in the recipe and in the `SLACK_REQUIRED_SCOPES` comment.
+
+The lesson: **mocks are perfect substitutes for the things you remembered to mock**. The shell, the OS, the network, the third-party API's actual response shape — those don't get mocked. Run the recipe on a clean machine before declaring a feature shipped. Every time.
+
+## The bot_id filter inversion
+
+This is the most subtle gotcha in the Slack adapter, and worth knowing before you touch anything Slack-related.
+
+`SlackHistoryBackfiller` (the `SessionFirstTouch` impl) reads `conversations.replies` and **drops messages with `bot_id` set**. Reasoning: those are the bot's own past replies. The use case records every synthetic event as `authorRole: 'user'` — recording bot replies as "user said" would corrupt the agent's context.
+
+The runtime MCP tool `slack_get_channel_history` (the one the agent calls mid-conversation) **preserves messages with `bot_id` set**. Reasoning: the agent might need to read another bot's QA reports to answer a question about them. Different code path, opposite filtering decision.
+
+If you change one filter, **think hard about whether you should change the other**. They look related but they aren't — they're answering different questions. Documented in the issue #26 body and in inline comments at both filter sites.
+
+## Configuration is in three tiers, not one
+
+The `docs/extending/configuration.md` table is short but important:
+
+| Tier | Examples | Where it lives |
+|---|---|---|
+| **Secret** | `SLACK_BOT_TOKEN`, `POSTGRES_URL`, `VOYAGE_API_KEY` | Process env. Validated by `SecretsSchema` (zod). Never in git. |
+| **Configuration** | Channel allowlists, idle timeouts, embedding model | `agentry.config.ts` (TypeScript). Committed to the fork. |
+| **Runtime-resolved** | Slack channel IDs, user names, message timestamps | Not pre-configured. The agent resolves at run time via tools. |
+
+The most common mistake: putting a runtime-resolved value into config. If you find yourself adding `SLACK_DEFAULT_CHANNEL_ID` to `.env`, stop and ask: shouldn't the agent know what channel it's in from the event itself? (Yes, it should. The `SessionPolicy.toAgentContext` hook gives it that.)
+
+## Where to start reading
+
+Suggested tour for a new contributor:
+
+1. `ARCHITECTURE.md` — the formal contract surface. Skim §3 (domain model) and §4 (ports), read §5 (use cases) carefully.
+2. `packages/core/src/ports/index.ts` — the actual port shapes in code.
+3. `packages/core/src/app/handle-incoming-message.ts` — the entire MVP use case in one file. Read the comments; they cite the contracts they depend on.
+4. `packages/adapter-channel-slack/src/slack-history-backfiller.ts` — the `SessionFirstTouch` reference impl. The closure-vs-findByRef story comes alive here.
+5. `docs/recipes/smoke-test.md` — what an operator actually does to bring this up.
+6. `docs/extending/*` — when you're ready to write your own adapter.
+7. `CHANGELOG.md` — what's shipped.
+
+Skip on first read: the test files (they assume you know the contracts), `packages/runtime/src/compose.ts` (the wiring is mechanical once you know the ports), `packages/adapter-store-pgvector/src/migrate/0001_init.sql` (the schema is what it is — read when you need to change it).
+
+## Lessons that didn't fit elsewhere
+
+- **`useLiteralKeys` lint infos** in `packages/core/src/app/handle-incoming-message.ts:124,181` are pre-existing (commit ae9b6412, 2026-04-26). Biome wants `obj.literal` not `obj['literal']`. Cosmetic. File a cleanup PR if scope allows; don't block other work on it.
+- **Port 3000 collision**: if you're a developer who also runs Next.js dev servers locally, agentry's Hono `/health` will collide. Use `PORT=3010` to avoid the dance. Slack Bolt's `SLACK_PORT=3001` is independent.
+- **`process.once('exit')` does not fire on signal-kill**. The Claude CLI runner's MCP-config tempfile cleanup needed explicit `SIGINT` and `SIGTERM` listeners after this was discovered live. If you write any process-lifetime cleanup, register all three.
+- **GitHub auto-close keywords are regex-y, not parse-y**. "Does not close #N" still auto-closes #N because the regex matches the substring. Reserve close-keywords (`closes`, `fixes`, `resolves`) for the *final* PR in a series; PRs A/B/C of N should reference the issue with `(see #N)` or similar.
+
+## When in doubt
+
+- **Architecture question?** Read `ARCHITECTURE.md` §1 (Goals & Non-Goals) before proposing an addition.
+- **"Should this be a port?"** Three drivers (three concrete adapters that would implement it). Until then, it's a private function in one adapter.
+- **"Should this be in core?"** Does the domain need it (yes → core), or does an adapter need it (yes → that adapter)? Shared utilities go to core only when 2+ adapters need them.
+- **Stuck on a workflow rule?** Check `~/.claude/rules/` (the maintainer's harness rules) and project `CLAUDE.md` (project conventions). If they conflict, project `CLAUDE.md` wins.
+
+Welcome aboard.

--- a/README.md
+++ b/README.md
@@ -6,38 +6,101 @@
 
 ## Status
 
-🚧 **Phase 3 build started.** Architecture (Phase 1, [ARCHITECTURE.md](./ARCHITECTURE.md))
-and KnowledgeStore design (Phase 2, [docs/design/knowledge-store.md](./docs/design/knowledge-store.md))
-are approved. Foundational packages and tooling are landing now; functional adapters
-follow. See the [project board](https://github.com/users/NakhunSong/projects/7) for
-current progress.
+✅ **Phase 3 (MVP slice) shipped.** Slack mention → Claude reply → both turns in pgvector, end-to-end. The hot path returns under 6ms (zero Slack API calls on subsequent mentions in the same thread). See `docs/recipes/smoke-test.md` for a 30-minute walkthrough on a fresh checkout.
 
-## Vision
+📚 **Phase 4 (extension guides) shipped.** This README plus `docs/extending/*` cover everything a fork needs to plug in a new channel, runner, embedding provider, or store.
 
-- **Channel-agnostic**: Slack first, but any input transport plugs in via the `InboundChannel` port (Discord, CLI, HTTP webhook, ...).
-- **Claude-subscription based**: Runs `claude` CLI under the hood — no separate API key juggling.
-- **Memory that learns**: Sessions are stored as raw episodic memory, then periodically distilled into semantic knowledge with provenance tracking, following an Extract → Cognify → Load pattern.
-- **Single-container deploy**: One `docker compose up` on a VPS gets you running. Postgres + pgvector for storage; graph layer is opt-in.
-- **Single-direction sync**: Framework updates flow downstream to your fork; your data stays yours.
+## Key features
 
-## Try it locally
+- **Channel-agnostic** — Slack today, Discord / Microsoft Teams / a CLI / a webhook tomorrow. The `InboundChannel` + `OutboundChannel` + `SessionPolicy` ports are the entire contract.
+- **Off-ack-path bootstrap** — channel adapters never block the inbound ack budget. `SessionFirstTouch` (channel-agnostic) runs inside the `JobRunner` queue.
+- **Claude-subscription based** — runs the `claude` CLI under the hood; no separate API key juggling. Direct-API runner is a constructor swap (see `docs/extending/agent-runner.md`).
+- **Three-layer memory** — relational (provenance) + vector (semantic) shipping today; graph (relational reasoning) opt-in in Phase 2+.
+- **Single-container deploy** — one `docker compose up` on a VPS. Postgres + pgvector for storage; no separate vector service.
+- **Single-direction sync** — framework updates push procedural assets (CLAUDE.md, skills, rules) to forks. User data (sessions, knowledge) is never touched by upstream merges.
 
-The MVP slice ([issue #21](https://github.com/NakhunSong/agentry/issues/21)) is
-end-to-end: post in a Slack thread → Claude reply → both turns persisted in
-Postgres. Walkthrough in [docs/recipes/smoke-test.md](./docs/recipes/smoke-test.md).
-The bundled `docker-compose.yml` is dev-only; production deployment lands in Phase 5.
+## Tech stack
+
+| | |
+|---|---|
+| Runtime | Node 22+ (24 recommended) |
+| Language | TypeScript 6 — strict + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` + `verbatimModuleSyntax` |
+| Module system | ESM only, `NodeNext` |
+| Package manager | pnpm 10.33.2 (pinned via `packageManager`) |
+| Test | Vitest 4 |
+| Lint + format | Biome 2 (single tool) |
+| Boundary enforcement | dependency-cruiser 17 |
+| Storage | Postgres 16 + pgvector |
+| Embeddings | Voyage `voyage-3.5` (1024-dim) by default |
+| Channels | Slack via `slack-bolt` 4 |
+| Agent | Anthropic `claude` CLI subprocess |
+
+## Quick start
+
+```bash
+pnpm install
+pnpm build
+
+# Postgres + pgvector
+docker compose up -d
+
+# Schema (idempotent)
+EMBEDDING_DIM=1024 \
+POSTGRES_URL=postgres://agentry:agentry@localhost:5432/agentry \
+node apps/cli/dist/main.js migrate
+
+# Server (after configuring .env)
+node --env-file=.env apps/server/dist/main.js
+```
+
+For the Slack-app side (manifest, ngrok tunnel, scope reinstall) plus the verification SQL, see [`docs/recipes/smoke-test.md`](./docs/recipes/smoke-test.md).
+
+## Environment variables
+
+Required at runtime — validated by `SecretsSchema` (zod) at startup; missing keys produce a `SecretsValidationError` listing every offender:
+
+| Key | Shape |
+|---|---|
+| `SLACK_BOT_TOKEN` | starts with `xoxb-` |
+| `SLACK_SIGNING_SECRET` | non-empty |
+| `POSTGRES_URL` | URL |
+| `VOYAGE_API_KEY` | non-empty |
+
+Optional:
+
+| Key | Default | Notes |
+|---|---|---|
+| `PORT` | `3000` | Hono `/health` endpoint |
+| `SLACK_PORT` | `3001` | Bolt receiver — must match the ngrok forward target |
+| `LOG_LEVEL` | `info` | pino log level |
+| `AGENT_WORKDIR` | `./seed/agent-workdir` | procedural memory root passed to the agent runner |
+| `AGENTRY_ENV_FILE` | `.env` | env-shadow check looks here |
+
+See `docs/extending/configuration.md` for the secret/config/runtime tier separation and how to add new keys when extending the framework.
+
+## Extending
+
+| Want to add | Read |
+|---|---|
+| Configuration / new secret | [`docs/extending/configuration.md`](./docs/extending/configuration.md) |
+| New channel (Discord, Teams, CLI, webhook) | [`docs/extending/channel-adapter.md`](./docs/extending/channel-adapter.md) |
+| Different agent runner (direct API, OpenAI, local LLM) | [`docs/extending/agent-runner.md`](./docs/extending/agent-runner.md) |
+| Different embedding provider (OpenAI, Cohere, self-host) | [`docs/extending/embedding-provider.md`](./docs/extending/embedding-provider.md) |
+| Alternative store (SQLite, DuckDB, Qdrant) | [`docs/extending/store-adapters.md`](./docs/extending/store-adapters.md) |
+| Architectural overview | [`ARCHITECTURE.md`](./ARCHITECTURE.md) |
+| Onboarding tour with rationale | [`FOR_ONBOARDING.md`](./FOR_ONBOARDING.md) |
 
 ## Roadmap
 
-| Phase | Scope |
-|---|---|
-| 1 | Architecture design (ports & adapters) |
-| 2 | KnowledgeStore + distillation pipeline design |
-| 3 | MVP slice — Slack adapter + claude CLI runner + pgvector |
-| 4 | Documentation & extension guides |
-| 5 | Docker compose & VPS deployment story |
+| Phase | Scope | Status |
+|---|---|---|
+| 1 | Architecture design (ports & adapters) | shipped |
+| 2 | KnowledgeStore + distillation design | shipped |
+| 3 | MVP slice — Slack + claude CLI + pgvector | shipped |
+| 4 | Documentation & extension guides | shipped |
+| 5 | Docker compose & VPS deploy story | next |
 
-Track progress in the [project board](https://github.com/users/NakhunSong/projects).
+Track current work in the [project board](https://github.com/users/NakhunSong/projects).
 
 ## License
 

--- a/docs/extending/agent-runner.md
+++ b/docs/extending/agent-runner.md
@@ -1,0 +1,182 @@
+# Agent runner
+
+An agent runner translates the framework's "produce a reply" intent into
+actual model calls. The default — `ClaudeCliAgentRunner` in
+`packages/adapter-runner-claude-cli` — shells out to the Anthropic
+`claude` CLI; this guide covers what the contract requires so you can
+swap it for a direct API client (Anthropic SDK, OpenAI, local LLM,
+mock for tests, etc.).
+
+## Contract
+
+```ts
+interface AgentRunner {
+  readonly kind: string;
+  run(input: AgentRunInput): AsyncIterable<AgentEvent>;
+}
+
+interface AgentRunInput {
+  readonly sessionId: SessionId;
+  readonly workdir: string;
+  readonly prompt: string;
+  readonly resumeKey?: string;
+  readonly context?: { readonly retrievedKnowledge: readonly RetrievedItem[] };
+  readonly abortSignal?: AbortSignal;
+}
+
+type AgentEvent =
+  | { type: 'text_delta';  text: string }
+  | { type: 'tool_call';   name: string; input: unknown }
+  | { type: 'tool_result'; name: string; output: unknown }
+  | { type: 'finished';    reason: 'complete' | 'error' | 'aborted'; usage: TokenUsage; resumeKey?: string }
+  | { type: 'error';       message: string; recoverable: boolean };
+```
+
+The shape is deliberately close to a streaming completion API so adapter
+code is short.
+
+### Three rules the framework relies on
+
+1. **Always end with `finished`.** Even on errors. Even on early termination.
+   `HandleIncomingMessage` reads `usage` and `reason` off this event to
+   record the agent turn. Skipping it leaves the use case waiting forever.
+2. **Yield `text_delta` for streamed output, accumulated by the use case.**
+   The use case concatenates them into the agent turn's `contentText` and
+   posts the assembled string via `OutboundChannel.reply`. There's no
+   per-delta flush at the channel layer at MVP.
+3. **`error` events do not replace `finished`.** If your runner surfaces
+   an `error`, also emit `finished` with `reason: 'error'`. The use case
+   uses `error` to decide whether to skip the reply; `finished` to record
+   the turn metadata.
+
+`tool_call` and `tool_result` are pass-through — the use case doesn't
+interpret them at MVP, but they're in the type so future observability
+features (token-usage logs, tool-use audit trail) don't need a port
+change.
+
+### `workdir` is the agent's procedural memory root
+
+The framework passes `input.workdir` as the working directory. For
+Claude CLI, this is where the subprocess looks for `CLAUDE.md`,
+`.claude/skills/`, `.claude/rules/`, and `.mcp.json`. agentry ships a
+default at `seed/agent-workdir/` and forks override per deployment. A
+direct-API runner would read these manually and stitch them into the
+system prompt.
+
+### `resumeKey` is opaque
+
+The framework passes `resumeKey` through unchanged on the next turn.
+Claude CLI uses it for `--resume <session-id>` so the model retains
+prior-turn KV cache. A direct-API runner without resume support can
+ignore it (and never emit it back); the framework will record `undefined`
+and pass `undefined` next time.
+
+## Reference: `ClaudeCliAgentRunner`
+
+Key implementation patterns worth copying:
+
+**Spawn seam for testability**
+```ts
+constructor(private readonly options: ClaudeCliAgentRunnerOptions = {}) { ... }
+async *run(input: AgentRunInput): AsyncIterable<AgentEvent> {
+  const spawnFn = this.options.spawn ?? defaultSpawn;
+  const child = spawnFn(binary, args, { cwd: input.workdir, ... });
+  ...
+}
+```
+
+Tests inject a fake `spawn` that returns a synthetic `ChildProcess` with
+controllable stdout — no real subprocess needed.
+
+**Stream parser owns frame state**
+The CLI emits NDJSON (one JSON object per line). `stream-parser.ts`
+holds a state machine that translates lines into `AgentEvent`s. Keep
+parsing isolated from spawn/IO logic so it's unit-testable in isolation.
+
+**MCP config tempfile lifecycle**
+When `options.mcpServers` is non-empty, the runner writes a
+process-private JSON file under `os.tmpdir()` (mode 0600, name includes
+the PID), passes its path to the CLI via `--mcp-config`, and registers
+cleanup hooks for `exit`, `SIGINT`, AND `SIGTERM`. The third one is
+non-obvious: `process.once('exit')` does NOT fire on signal-kill, so
+without the explicit `SIGTERM` listener the tempfile leaks on
+`kill -TERM` in containerized deployments. See PR #69 for the live
+verification.
+
+> **Default-fatal suppression caveat**: registering ANY signal listener
+> in Node suppresses the default terminate-on-signal behavior. Embedders
+> who relied on that (e.g., a script that just exits when SIGTERM hits)
+> must drive their own `process.exit()` after cleanup. `apps/server`
+> already does this through the shutdown handler; embedders importing
+> the runner directly need to match.
+
+## Wiring
+
+Through compose:
+
+```ts
+// packages/runtime/src/compose.ts (excerpt — already done in the runtime)
+const agentRunner = new ClaudeCliAgentRunner({
+  ...(args.spawn !== undefined ? { spawn: args.spawn } : {}),
+  ...(mcpServers.length > 0 ? { mcpServers } : {}),
+});
+```
+
+To swap in your own runner, you'd either:
+
+- **Fork `compose.ts`** and substitute the constructor (heaviest, but the
+  test seams come along for free).
+- **Build a parallel runtime** in `packages/runtime-myrunner/` that
+  shares storage adapters but constructs your runner. Useful when
+  multiple deployments use different runners and you don't want a flag
+  fight inside one compose.
+
+There is intentionally no `agentRunner` slot in `BuildChannelsResult`
+today — runner choice is deeper than a per-channel decision (one runner
+typically serves all channels). If you need per-channel runners (an
+internal Slack bot using GPT-4 while a CLI bot uses Claude), file an
+issue with the driver and the contract will get a slot.
+
+## MCP servers
+
+`McpServerConfig` (in `packages/core/src/domain/mcp-server.ts`) is the
+DTO channel adapters use to expose tools to the agent. The runtime
+collects every adapter's MCP servers from `BuildChannelsResult.mcpServers`
+and passes the union to the runner constructor. The runner's job is to
+materialize them in the format the underlying agent expects — for
+Claude CLI, an `.mcp.json` file at a path passed via `--mcp-config`.
+
+A direct-API runner would convert `McpServerConfig[]` to the SDK's
+`tools` parameter shape, or reject MCP servers entirely (with a
+descriptive error at construction) if it doesn't support them.
+
+## Testing
+
+Two flavors of test for runner adapters:
+
+1. **Unit tests with a fake spawn / fake transport.** Verify event
+   sequencing — does the runner yield `finished` on every termination
+   path? Does an `error` event still get followed by `finished`? Does
+   `abortSignal.abort()` produce `reason: 'aborted'`?
+2. **Integration test with the real binary / SDK.** Smaller — typically
+   one happy-path "say hello" to confirm the prompt + workdir wiring
+   actually works end-to-end. Skip in CI by default; run on demand
+   during development. The Claude CLI runner uses `__fixtures__/` for
+   recorded NDJSON streams the parser tests can replay deterministically.
+
+## Common gotchas
+
+- **Forgetting `finished` on early return.** If you `return` from your
+  generator before yielding `finished`, the use case waits indefinitely.
+  Even the "subprocess streams unavailable" sad path in the Claude CLI
+  runner emits an `error` AND a `finished` before returning.
+- **Yielding text after `finished`.** The use case stops consuming once
+  it sees `finished`. Late `text_delta`s are silently dropped — usually
+  a bug in your buffering, not the framework.
+- **Token usage on error.** Emit zero usage (`{ input: 0, output: 0 }`)
+  rather than `undefined` — the type is required. Some adapters know
+  partial usage even on error and should report it; that's fine.
+- **`workdir` doesn't get auto-created.** The framework passes whatever
+  string the operator configured — typically `./seed/agent-workdir` —
+  and assumes it exists. If your runner needs to bootstrap a fresh
+  directory per session, do it inside `run()` before spawning.

--- a/docs/extending/channel-adapter.md
+++ b/docs/extending/channel-adapter.md
@@ -1,0 +1,255 @@
+# Channel adapter
+
+A channel adapter teaches agentry to talk to a new transport — Slack today,
+Discord / Microsoft Teams / a CLI / a webhook tomorrow. This guide walks
+the contract using `packages/adapter-channel-slack` as the reference.
+
+## What you implement
+
+Every adapter ships at minimum **three ports** plus an optional fourth:
+
+| Port | Required? | Role |
+|---|---|---|
+| `InboundChannel` | yes | Long-running listener; pushes `IncomingEvent`s to the framework |
+| `OutboundChannel` | yes | One-shot `reply(target, content)` |
+| `SessionPolicy` | yes | How the channel maps an event to a session and decides when one ends |
+| `SessionFirstTouch` | no | Bootstrap work on a session's first contact (e.g., Slack thread history backfill) |
+
+All four live in `@agentry/core`'s `ports/` directory. The composition
+root maps `channelKind: ChannelKind` (an open string like `'slack'`,
+`'discord'`, `'cli'`) to the concrete instance.
+
+## Boundary rules (non-negotiable)
+
+- An adapter package only imports from `@agentry/core` (enforced by
+  `dependency-cruiser`). No imports from other adapters, `runtime`, or
+  `apps`.
+- TypeScript: ESM only (`NodeNext` resolution), strict mode +
+  `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` +
+  `verbatimModuleSyntax`. Use `import type` for type-only imports;
+  `.js` extension on every relative import even though the source is
+  `.ts`.
+- No `any`. Define proper types at every boundary. Use the same
+  `Logger` interface from core if you need observability.
+
+## InboundChannel
+
+```ts
+interface InboundChannel {
+  readonly kind: ChannelKind;
+  start(handler: (event: IncomingEvent) => Promise<void>, signal: AbortSignal): Promise<void>;
+}
+```
+
+The contract has two load-bearing rules:
+
+1. **`handler(event)` MUST return promptly** — typically before the
+   agent has produced its reply. Slack enforces a 3-second ack budget;
+   any blocking work in the handler will time out and trigger a
+   redelivery storm. The framework's `HandleIncomingMessage` does only
+   `findOrCreate(session)` + `JobRunner.enqueue(...)` then returns —
+   adapters that need bootstrap work belong in `SessionFirstTouch`
+   (which runs *inside* the queued job, not on the ack path).
+2. **`start()` resolves only when listening stops** — either the
+   `AbortSignal` fires or the underlying transport closes. The
+   framework's shutdown sequence calls `signal.abort()` and awaits
+   every inbound channel's `start()` promise.
+
+### Slack reference
+
+`SlackInboundChannel` (in `packages/adapter-channel-slack/src/slack-inbound-channel.ts`):
+
+- Verifies OAuth scopes against `SLACK_REQUIRED_SCOPES` before
+  registering Bolt listeners — fails fast on misconfig instead of
+  hitting a runtime "missing_scope" 24 hours later.
+- Single-shot `start()` — a second call would register a duplicate
+  Bolt event handler and double every event. The composition root
+  builds a new instance per restart.
+- The `app_mention` handler maps the envelope to `IncomingEvent` and
+  awaits `handler(live)` — that's it. Backfill belongs to
+  `SessionFirstTouch`, not here.
+- The handler wraps in `try/catch` and **swallows** errors with
+  `log.error` rather than letting Bolt leave the request un-acked.
+  An unhandled throw causes Slack to redeliver — idempotency would
+  catch the dup but you'd burn cycles on every redelivery.
+
+```ts
+app.event('app_mention', async ({ event, body, logger }) => {
+  try {
+    const live = mapAppMentionToIncomingEvent({ event, ...body });
+    await handler(live);
+  } catch (err) {
+    logger.error({ err }, 'slack app_mention handling failed');
+  }
+});
+```
+
+## OutboundChannel
+
+```ts
+interface OutboundChannel {
+  readonly kind: ChannelKind;
+  reply(target: ReplyTarget, content: ReplyContent): Promise<ReplyAck>;
+}
+```
+
+One-shot reply only. There is intentionally no `update(messageRef, content)`
+at MVP — many transports (email, generic HTTP) don't support edit, and
+adding it later when a real UX gap appears is cheaper than removing it.
+
+`ReplyTarget` carries the same `threading` blob the inbound channel
+attached to the original `IncomingEvent` — adapters cooperate with
+themselves by reading whatever opaque routing keys they originally set
+(Slack: `channel` + `thread_ts`; Discord: `thread_id`; etc.). The
+framework treats `threading` as black-box.
+
+`ReplyAck` returns the adapter-native message id (Slack `ts`, Discord
+`message_id`) plus a `postedAt` timestamp.
+
+## SessionPolicy
+
+```ts
+interface SessionPolicy {
+  readonly channelKind: ChannelKind;
+  computeNativeRef(event: IncomingEvent): ChannelNativeRef;
+  idleTimeoutMinutes(): number;
+  shouldEndOn(event: SessionLifecycleEvent): boolean;
+  toAgentContext?(event: IncomingEvent): Readonly<Record<string, string>>;
+}
+```
+
+- `computeNativeRef` — pure, sync; produces the channel-specific
+  session key. The framework feeds this to
+  `SessionStore.findOrCreate(channelKind, ref, tenantId)`. Slack uses
+  `slack:${channel}:${thread_ts}`; a CLI adapter might use
+  `cli:${process.env.AGENT_SESSION_ID}`. Convention: `<kind>:<scope>`.
+- `idleTimeoutMinutes` — when `JobRunner` fires the idle timer, this
+  controls when an active session transitions to `idle`. Slack
+  defaults to 24h.
+- `shouldEndOn` — predicate over framework-observed lifecycle events
+  (idle timer, transport close, user-left). Slack only ends on
+  `channel_close`; everything else stays.
+- `toAgentContext` (optional) — returns string-valued context the
+  framework prepends to the agent prompt under
+  `CHANNEL_CONTEXT_HEADER`. The Slack policy returns
+  `{channelId, threadTs}` so the agent can call
+  `slack_get_channel_history(channelId)` without the user spelling
+  out the ID. Implement this whenever your channel adapter ships
+  MCP tools that need self-aware context.
+
+## SessionFirstTouch (optional)
+
+```ts
+interface SessionFirstTouch {
+  onFirstTouch(input: { session: Session; event: IncomingEvent }): Promise<readonly IncomingEvent[]>;
+}
+```
+
+Channel-agnostic session-bootstrap hook. Invoked **inside the
+`JobRunner` queue** — off the inbound ack path — on each session's
+first contact. Returns synthetic `IncomingEvent`s the framework
+records as user turns BEFORE the live event's agent run.
+
+Implementations own their "already done" flag (typically via
+`session.metadata`) and reconcile single-process FIFO + multi-process
+drift via `SessionStore.findByRef`.
+
+**Failure semantics**: if `onFirstTouch` throws, the use case logs
+and still processes the live event. Synthetic delivery is
+best-effort.
+
+The Slack reference (`SlackHistoryBackfiller`) does:
+
+1. Closure-snapshot check on `session.metadata.slackBackfilled` — if
+   true, return `[]` (cheap path; no I/O).
+2. `findByRef` re-read for the multi-process race — if a sibling
+   worker already flipped the flag between `findOrCreate` and now,
+   return `[]` (no `setMetadata`, no Slack API).
+3. Otherwise fetch `conversations.replies(limit: 1000)`, map to
+   synthetic events (filter bot messages and the live mention),
+   `setMetadata({slackBackfilled: true})`, return synthetics.
+
+The hot path measured live: **6ms** (DB read + closure check, zero
+Slack API calls). Cold path: ~378ms (one `conversations.replies`).
+
+Skip implementing `SessionFirstTouch` entirely if your channel has
+no per-session bootstrap (a CLI adapter, an HTTP webhook). The
+framework simply doesn't invoke it for that channel kind.
+
+## Wiring it into the composition root
+
+```ts
+// apps/server/src/main.ts (excerpt)
+const handles = await compose({
+  config,
+  secrets,
+  buildChannels: ({ sessionStore, logger }) => {
+    const policy = new MyChannelPolicy();
+    const outbound = new MyOutboundChannel({ apiKey: secrets.MY_API_KEY });
+    const firstTouch = new MyFirstTouch({ sessionStore, sessionPolicy: policy, logger }); // optional
+    const inbound = new MyInboundChannel({ apiKey: secrets.MY_API_KEY, port: 4000 });
+    return {
+      inboundChannels: [inbound],
+      outboundChannels: new Map([[policy.channelKind, outbound]]),
+      sessionPolicies: new Map([[policy.channelKind, policy]]),
+      sessionFirstTouches: new Map([[policy.channelKind, firstTouch]]), // omit if not implementing
+      mcpServers: [...], // optional, see agent-runner guide
+    };
+  },
+});
+```
+
+The `buildChannels` factory receives `{sessionStore, logger}` from
+compose so adapters can take them as constructor args.
+
+## Adapter MCP tools (optional)
+
+Adapters that expose tools to the agent — letting it call
+`slack_get_channel_history(channelId)` mid-conversation — ship an
+MCP server config via `BuildChannelsResult.mcpServers`. See
+`packages/adapter-channel-slack/src/slack-mcp-config.ts` for the
+Slack reference. The runtime forwards the config to the
+`AgentRunner`, which wires it into the agent process's MCP client.
+
+## Test seams
+
+Slack tests inject a fake `App` (Bolt) and a fake `fetch` so unit
+tests skip the real HTTP listener and Slack auth:
+
+```ts
+const ch = new SlackInboundChannel({
+  ...baseOpts,
+  app: fakeApp(),     // skips Bolt's HTTP bind
+  fetch: fakeFetchOk(['app_mentions:read', 'chat:write']), // skips auth.test
+});
+```
+
+Constructor seams (preferred over module-level singletons or env
+checks) keep your tests deterministic without `process.env` stubbing.
+
+The boundary tax: depcruiser forbids adapter packages from importing
+`@agentry/testing`, so you can't reuse `silentLogger` or other
+testing fakes. Either inline a minimal `Logger` shape in the test file
+(see `slack-inbound-channel.test.ts`) or accept the duplication.
+
+## Common gotchas
+
+- **Slack manifest changes require reinstall.** Adding a scope to
+  `SLACK_REQUIRED_SCOPES` doesn't auto-grant it on existing installs;
+  the `verifySlackScopes` call at startup will throw and the operator
+  must reinstall the app.
+- **Idempotency.** `IncomingEvent.idempotencyKey` is your hook for
+  dedup; the framework records it on the user turn so a redelivery
+  doesn't double-write. Compute it from a transport-stable id (Slack:
+  `event_id`, never `ts`).
+- **Threading is opaque.** `ThreadingMetadata` is `Readonly<Record<string, unknown>>`
+  — the framework never reads it. Your adapter is the sole reader on
+  both ends; pick keys you control. Slack uses
+  `{channel, thread_ts, message_ts, team_id}`.
+- **Synthetic events get `metadata.synthetic = true`.** The use case
+  records them as user turns then short-circuits — no agent run, no
+  reply. Don't forget the flag when emitting from `SessionFirstTouch`.
+- **DM support is a separate concern.** Slack DMs would need a
+  different `channelKind` (e.g., `'slack-dm'`) plus its own
+  `SessionPolicy.computeNativeRef` — DMs key by user, not thread.
+  Deferred until a real driver appears.

--- a/docs/extending/configuration.md
+++ b/docs/extending/configuration.md
@@ -53,21 +53,53 @@ const secrets = loadSecrets(env);
 Adapters consume `secrets` through normal property access — they don't know
 or care where the values originated.
 
-### Adapter-specific secrets *(open question)*
+### Adapter-specific secrets
 
-The current `SecretsSchema` is centralized in `packages/runtime`. As more
-adapters land, each will want its own keys (e.g., a Discord adapter adding
-`DISCORD_BOT_TOKEN`). The extension contract is not yet decided:
+The pattern that emerged after the Slack + Claude CLI + Voyage + pgvector
+adapters all shipped: **`SecretsSchema` stays centralized in `runtime`,
+adapters never import `Secrets`**. The composition root reads each value
+from the schema and passes plain strings into adapter constructors.
 
-- **Option A** — extend the central schema in `runtime` for every adapter.
-  Simple, but `runtime` accretes adapter-specific fields.
-- **Option B** — each adapter exports its own `loadXxxSecrets()`.
-  Keeps boundaries clean, but the composition root juggles N loaders.
-- **Option C** — adapters export schema fragments; `runtime` provides a
-  builder that merges them at composition time.
+```ts
+// packages/runtime/src/config/secrets.ts — single source of truth
+export const SecretsSchema = z.object({
+  SLACK_BOT_TOKEN: z.string().startsWith('xoxb-', 'must start with "xoxb-"'),
+  SLACK_SIGNING_SECRET: z.string().min(1, 'must not be empty'),
+  POSTGRES_URL: z.url(),
+  VOYAGE_API_KEY: z.string().min(1, 'must not be empty'),
+});
 
-This will be settled when the second adapter (issue #18, Slack) lands.
-Until then, treat `SecretsSchema` as the single source of truth.
+// apps/server/src/main.ts — composition root maps env → adapter args
+const secrets = loadSecrets();
+const slackClient = new WebClient(secrets.SLACK_BOT_TOKEN);
+const inbound = new SlackInboundChannel({
+  botToken: secrets.SLACK_BOT_TOKEN,
+  signingSecret: secrets.SLACK_SIGNING_SECRET,
+  port: slackPort,
+});
+```
+
+The benefit beyond schema simplicity: **adapters stay testable without
+env**. `SlackInboundChannel`'s constructor takes a plain `botToken` string
+— unit tests pass `'xoxb-test'`, no `process.env` stubbing.
+
+**To add a new adapter that needs a secret** (e.g., a Discord adapter):
+
+1. Extend `SecretsSchema` with the new key (with a validator) and update
+   `.env.example`.
+2. The adapter constructor accepts the value as a plain option — it does
+   NOT import `Secrets` or `loadSecrets`.
+3. Wire the value at the composition root:
+   ```ts
+   const inbound = new DiscordInboundChannel({
+     botToken: secrets.DISCORD_BOT_TOKEN,
+   });
+   ```
+
+If the centralized schema gets large enough that contributors fight over
+it (≥ 8–10 adapters in active use), revisit by splitting into per-adapter
+schema fragments merged at composition time. Until then, the central
+schema keeps things obvious — one place to find every required key.
 
 ## Configuration (`agentry.config.ts`)
 

--- a/docs/extending/embedding-provider.md
+++ b/docs/extending/embedding-provider.md
@@ -1,0 +1,150 @@
+# Embedding provider
+
+An embedding provider turns text into vectors. The default —
+`VoyageEmbeddingProvider` in `packages/adapter-embedding-voyage` — calls
+the Voyage API; this guide covers the contract for swapping in OpenAI,
+Cohere, a self-hosted model, etc.
+
+## Contract
+
+```ts
+interface EmbeddingProvider {
+  readonly model: string;
+  readonly dimension: number;
+  embed(texts: readonly string[]): Promise<readonly Float32Array[]>;
+}
+```
+
+The port is small on purpose. Three constraints worth internalizing:
+
+- **`dimension` is declared, not inferred.** The composition root reads
+  it at startup and the `KnowledgeStore` checks it against the actual
+  pgvector column dimension. A mismatch is fatal — see the EMBEDDING_DIM
+  gotcha below.
+- **Output preserves input order.** `embed(['a', 'b'])[0]` is the vector
+  for `'a'`. Adapters that batch internally must reassemble.
+- **Empty input is allowed**, returns `[]`. Adapters that error on empty
+  request bodies (some APIs do) should short-circuit.
+
+Batching, retries, and rate-limit policy belong inside the adapter — the
+port is pure declaration.
+
+## Reference: `VoyageEmbeddingProvider`
+
+```ts
+const embeddings = new VoyageEmbeddingProvider({
+  apiKey: secrets.VOYAGE_API_KEY,
+  model: 'voyage-3.5',     // optional; default 'voyage-3.5'
+  batchSize: 128,          // optional
+  maxRetries: 3,           // optional
+});
+```
+
+Patterns worth copying:
+
+- **Model → dimension as a static map.**
+  ```ts
+  const MODEL_DIMENSIONS: Record<VoyageModel, number> = {
+    'voyage-3.5': 1024,
+  };
+  ```
+  No per-call lookup against an API; the dimension is a compile-time
+  fact for each model. Adding `voyage-3-large` is a one-line table edit
+  plus widening the `VoyageModel` union.
+- **`fetch` constructor seam.**
+  ```ts
+  this.fetchFn = options.fetch ?? globalThis.fetch;
+  ```
+  Tests pass a `vi.fn()` that returns canned responses; production uses
+  the global fetch. No HTTP mocking framework needed.
+- **Batching via slicing**, not request multiplexing. Voyage's API
+  accepts up to N inputs per request — the adapter slices the input
+  array and concatenates results back in order.
+- **Retry-After respected, capped at 30s.** A misconfigured server
+  returning `Retry-After: 86400` should not pause your bot for a day.
+  Cap it at a sane upper bound.
+
+## Wiring
+
+Already done in `compose.ts`:
+
+```ts
+const embeddingProvider = new VoyageEmbeddingProvider({
+  apiKey: secrets.VOYAGE_API_KEY,
+  ...(args.fetch !== undefined ? { fetch: args.fetch } : {}),
+});
+```
+
+Swapping providers means substituting this constructor — typically by
+forking compose or building a parallel runtime. There's no per-channel
+or per-deployment slot for embedding providers; the choice is one per
+runtime.
+
+## EMBEDDING_DIM ↔ Postgres column dimension
+
+The single most common operational pitfall. Pgvector columns are
+declared with a fixed dimension at migration time:
+
+```sql
+ALTER TABLE knowledge_items ADD COLUMN embedding vector(1024);
+```
+
+If the embedding provider ships vectors of a different size, every
+`KnowledgeStore.upsertItem` call fails with `expected 1024 dimensions,
+not N`.
+
+The migrator reads `EMBEDDING_DIM` from env at apply time and bakes it
+into the column:
+
+```bash
+EMBEDDING_DIM=1024 \
+POSTGRES_URL=postgres://... \
+node apps/cli/dist/main.js migrate
+```
+
+When swapping providers (e.g., switching from `voyage-3.5` (1024) to
+`text-embedding-3-large` (3072)):
+
+1. **Drop and recreate the volume** if you can: `docker compose down -v`.
+   The migrator runs from scratch with the new dim.
+2. **Otherwise** add a migration that does `ALTER COLUMN embedding TYPE
+   vector(NEW_DIM) USING NULL` + clears the data. There's no in-place
+   resize that preserves vectors — the embedding space is different.
+
+Document the chosen dim in your fork's README so operators don't
+discover it via a runtime crash.
+
+## Testing
+
+The Voyage adapter ships two test surfaces:
+
+- `voyage-embedding-provider.test.ts` — unit tests with `fetch` injection
+  for batching, retry-after honoring, error-shape parsing, dimension
+  consistency.
+- `__integration__/` — live-API tests that hit voyageai.com when
+  `VOYAGE_API_KEY` is set in env. Skipped in CI; run on demand to verify
+  the API contract hasn't drifted.
+
+When implementing your own provider, mirror this split. The unit suite
+catches API shape changes during refactors; the integration suite
+catches the API itself drifting (which has happened — historically
+Voyage renamed `voyage-3` to `voyage-3.5`).
+
+## Common gotchas
+
+- **Returning `number[]` instead of `Float32Array`.** The pgvector
+  driver does the right thing with both, but the contract is
+  `Float32Array` and stricter consumers (e.g., a future
+  `VectorStoreDirectIngest`) will assume it. `Float32Array.from(arr)`
+  is the conversion.
+- **Throwing on empty input.** Some APIs reject `inputs: []` with a
+  400. The port contract requires `embed([])` to return `[]`; handle
+  the empty case before constructing the request.
+- **Forgetting `dimension`.** It's a `readonly` property, easy to
+  forget in a class skeleton. The `KnowledgeStore` startup check will
+  catch it (NaN vs the column dim) but the error message is opaque —
+  worth declaring up front.
+- **Token-budget drift.** Voyage charges per-token, per-model. Tests
+  with real API calls cost real money; gate them on `VOYAGE_API_KEY`
+  presence, not on a `--integration` flag, so a CI job that
+  accidentally sets the key doesn't drain credit.

--- a/docs/extending/store-adapters.md
+++ b/docs/extending/store-adapters.md
@@ -1,0 +1,196 @@
+# Store adapters
+
+agentry persists two domain concepts: **sessions/turns** (episodic memory)
+and **knowledge items** (semantic memory). The default —
+`PgvectorSessionStore` + `PgvectorKnowledgeStore` in
+`packages/adapter-store-pgvector` — uses Postgres + pgvector. This guide
+covers the contract for swapping in another backend (SQLite + sqlite-vss,
+DuckDB, Qdrant + Postgres, an external vector DB, etc.).
+
+> **Recommendation up front**: don't swap unless you have a concrete
+> driver. pgvector + Postgres covers the MVP slice with one container, no
+> separate vector service, ACID guarantees on session writes, and a
+> migration path that already ships. The "split vector + relational"
+> patterns are higher operational cost without compensating wins until
+> you're at scale or have a hard deployment constraint.
+
+## Two ports, separate decisions
+
+**Session store** is operationally hot (every turn writes; every mention
+reads-or-creates). **Knowledge store** is operationally rare (ingestion
++ retrieval). Splitting backends per port is sometimes the right call
+(e.g., Postgres for sessions, Qdrant for knowledge); the framework treats
+them independently.
+
+## SessionStore
+
+```ts
+interface SessionStore {
+  findOrCreate(channelKind, channelNativeRef, tenantId): Promise<Session>;
+  findByRef(channelKind, channelNativeRef, tenantId): Promise<Session | null>;
+  recordTurn(sessionId, turn: TurnInput): Promise<Turn>;
+  getRecentTurns(sessionId, limit): Promise<readonly Turn[]>;
+  updateStatus(sessionId, status: SessionStatus): Promise<void>;
+  setMetadata(sessionId, patch: Readonly<Record<string, unknown>>): Promise<void>;
+  listSessionsForDistillation(criteria): Promise<readonly SessionId[]>;
+}
+```
+
+### Load-bearing semantics
+
+- **`findOrCreate` is UPSERT.** Atomic; concurrent calls for the same
+  `(channelKind, ref, tenantId)` resolve to the same session id. Pgvector
+  uses `INSERT ... ON CONFLICT DO UPDATE RETURNING *`. SQLite needs
+  `INSERT OR IGNORE` + a follow-up `SELECT`; document that fact in your
+  adapter so reviewers know the two-statement window is intentional.
+- **`findByRef` is read-only.** Lifted in PR #70 for ack-path hot loops:
+  the Slack `SessionFirstTouch` impl checks "is this session already
+  backfilled?" without an UPSERT roundtrip. Implementations MUST NOT
+  bump `last_active_at` or any other side-effect column. Pgvector
+  integration test asserts this with a before/after comparison; the
+  same test pattern catches drift in any backend.
+- **`recordTurn` returns the persisted `Turn`** including `seqNo` (server-
+  assigned monotonically per session) and `createdAt`. Don't compute
+  `seqNo` in the adapter caller; it's a server-side concern with
+  concurrency implications (pgvector uses `RETURNING seq_no` from a
+  stored `nextval` per session).
+- **`setMetadata` is a shallow merge.** Pgvector implements it with
+  PostgreSQL's `||` operator on `JSONB`. A nested `slack: { backfilled:
+  true }` write would clobber sibling `slack.*` keys — that's why the
+  Slack adapter uses flat-prefixed keys like `slackBackfilled` (see
+  ARCHITECTURE.md §4.3 + the `SLACK_BACKFILLED_METADATA_KEY` constant).
+  If your backend can do an atomic deeper merge cheaply, document the
+  upgrade — the use case will benefit from a per-key conditional update
+  someday.
+- **`listSessionsForDistillation`** powers the Phase 2 distillation
+  trigger; criteria-driven, returns ids only (the distillation
+  pipeline batches the actual reads). MVP can return `[]` if you're
+  not running distillation yet — the use case handles empty gracefully.
+
+### Session/turn data model
+
+See `packages/core/src/domain/session.ts` for the canonical types. Notes
+the schema must enforce:
+
+- `(tenantId, channelKind, channelNativeRef)` is unique per session.
+- Turns belong to a session via `sessionId`; `seqNo` is dense and
+  per-session monotonic (not global).
+- `metadata` and `participants` are JSONB-shaped — adapters store opaque
+  blobs.
+- `distilledThroughSeqNo` is `bigint` — needed because long-lived
+  sessions can exceed `int32` over years.
+
+## KnowledgeStore
+
+```ts
+interface KnowledgeStore {
+  recordSource(ref: SourceRefInput): Promise<SourceId>;
+  upsertItem(item: KnowledgeItemInput): Promise<KnowledgeId>;
+  retrieve(query: RetrievalQuery): Promise<RetrievalResult>;
+  deleteBySource(sourceId: SourceId): Promise<void>;
+  deleteByExternalId(tenantId: TenantId, externalId: string): Promise<void>;
+  listByTenant(tenantId: TenantId, filter: ItemFilter): AsyncIterable<KnowledgeItem>;
+}
+```
+
+### Load-bearing semantics
+
+- **`upsertItem` is dedup-aware.** Pgvector uses
+  `UNIQUE(tenant_id, external_id)` for source-derived items and a
+  canonical-hash check for distilled items. Adapters MUST honor the
+  uniqueness contract — a duplicate write should update, not insert.
+  The schema (`packages/adapter-store-pgvector/src/migrate/0001_init.sql`)
+  is the spec.
+- **`retrieve` accepts a `RetrievalQuery`** with `text` (the embedding
+  query string), `tenantId`, `mode: 'semantic' | 'hybrid' | 'relational'`,
+  `topK`, optional `filters`, and optional `applyRecencyDecay`. The
+  adapter handles the embedding (it owns the `EmbeddingProvider`
+  reference) and the vector search. `'hybrid'` and `'relational'` modes
+  are reserved for Phase 2+ graph-augmented adapters — a `'semantic'`-only
+  adapter is the MVP minimum (throw on the other modes with a
+  descriptive error until your adapter implements them).
+- **`listByTenant` is `AsyncIterable`.** Streaming on purpose — knowledge
+  bases can outgrow memory. Pgvector returns server-side cursor results
+  page by page; an in-memory or smaller-scale adapter can `yield* arr`
+  but the consumer code shouldn't have to change.
+- **`deleteByExternalId` filters by `source_type='project_seed'`
+  internally** — defense-in-depth against an `external_id` collision
+  across source types under future schema relaxation. Honor the same
+  filter even if your schema makes the collision impossible today.
+
+### Dimension consistency
+
+The knowledge store and the embedding provider must agree on vector
+dimension. Pgvector validates this once at composition time (the column
+type carries it). Other backends (Qdrant collections, FAISS indexes)
+typically validate per-write — fail fast at startup by throwing from
+the store constructor when its declared dimension and
+`embeddingProvider.dimension` disagree, rather than letting writes
+silently fail later.
+
+See `docs/extending/embedding-provider.md` for the EMBEDDING_DIM
+operational story.
+
+## Migrations
+
+Pgvector ships its schema as numbered SQL files
+(`migrate/0001_init.sql`) plus a `runMigrations` runner that records
+applied filenames in `_agentry_migrations`. The CLI (`apps/cli`)
+exposes this as `agentry migrate`. Reapplying a migration is a no-op.
+
+If you implement an alternative store, ship a migrator with the same
+shape — file-per-migration, idempotent runner, recorded in a tracking
+table. The smoke recipe (`docs/recipes/smoke-test.md`) calls one
+command and your adapter has to match.
+
+## Wiring
+
+Already done in `compose.ts`:
+
+```ts
+const sessionStore = new PgvectorSessionStore(pool);
+const knowledgeStore = new PgvectorKnowledgeStore({
+  pool,
+  embeddings: embeddingProvider,
+});
+```
+
+To swap stores: fork compose, substitute the constructors, update the
+migrator entry point. There's no per-deployment slot — store choice is
+runtime-wide.
+
+## Integration test recipe
+
+Pgvector ships an `__integration__/` suite that spins up a test database
+and exercises the contract end-to-end:
+
+- `findOrCreate` is atomic under concurrent calls.
+- `findByRef` returns null on miss + doesn't touch `last_active_at`.
+- `recordTurn` produces dense per-session `seqNo`s.
+- `setMetadata` merges shallowly (and which keys collide).
+- `upsertItem` updates on duplicate `external_id`.
+- `retrieve` ranks by cosine similarity (or whatever your backend uses)
+  and respects `tenantId` isolation.
+
+When implementing a new store, mirror this suite. Contract conformance
+is a per-backend matter — use the suite as a checklist + safety net.
+
+## Common gotchas
+
+- **`tenantId` isolation.** Every read MUST filter by `tenantId`.
+  Multi-tenant deployments rely on this for data isolation; the use
+  case passes it through every call but the adapter is the enforcer.
+  pgvector tests assert cross-tenant returns empty — copy the assertion.
+- **`bigint` for `seqNo` and `distilledThroughSeqNo`.** TS `number`
+  doesn't fit. Pgvector returns `bigint` from `pg`; SQLite needs
+  manual conversion. Don't downcast.
+- **Connection pool lifecycle.** Pgvector's `pool.end()` is called
+  during `shutdown()` AFTER `jobRunner.drain()` — running jobs may
+  still need pool access to record their final turns. If your store
+  has the same separation, make the same call ordering explicit in
+  your shutdown sequence.
+- **`AsyncIterable` cleanup.** `listByTenant` consumers may abandon the
+  iterator early (early `return` from a `for await`). Implementations
+  must handle the implicit `return()` call and release server-side
+  resources (cursors, connections). Pgvector uses `try/finally` around
+  the cursor.


### PR DESCRIPTION
## Summary

Phase 4 docs pass — everything a fork needs to self-serve.

- **`docs/extending/`** — four new contract guides (channel adapter, agent runner, embedding provider, store adapters) with the existing `configuration.md` updated to close the previously open question on adapter-specific secrets
- **`README.md`** — quick start, env-var table, links into every extension guide
- **`CHANGELOG.md`** — Keep a Changelog format with Phase 1–3 user-facing highlights
- **`CONTRIBUTING.md`** — fork + sync model + upstream contribution flow
- **`FOR_ONBOARDING.md`** — engaging codebase tour with rationale and lessons learned (per global rule)

## Why

Phase 4 epic outcome: \"developer can clone, configure, and deploy a personal agent in under an hour using only docs.\" The MVP slice (#21) shipped in Phase 3, but \`docs/extending/\` only had a single config guide and there was no README quickstart, no changelog, no contributor guidance. Forks were on their own.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` 0 errors / 0 warnings (6 pre-existing \`useLiteralKeys\` infos in unrelated files; commit \`ae9b6412\`)
- [x] \`pnpm test\` — 223 passed (5 skipped pre-existing)
- [x] \`pnpm depcheck\` — no dependency violations
- [x] Every internal markdown link points at a file that exists in this branch
- [x] Advisor self-review caught + fixed 4 factual claims:
  - \`RetrievalQuery.mode\` is \`'semantic' | 'hybrid' | 'relational'\` (not just two)
  - \`KnowledgeStoreInitError\` doesn't exist — rewrote as a generic prescription
  - \`seed/agent-workdir/.claude/skills/\` and \`.claude/rules/\` don't exist yet — qualified as forward-looking
  - \`README.md\` \"Phase 4 in progress\" → \"shipped\" (true at merge time)

## Out of scope (followups, file when a driver appears)

- \`docs/recipes/\` second recipe (production-style deploy walkthrough) — Phase 5 territory
- Pre-existing \`useLiteralKeys\` lint cleanup in \`packages/core/src/app/handle-incoming-message.ts:124,181\` and \`packages/testing/src/app/handle-incoming-message.test.ts\` (4 locations) — cosmetic, predates this branch
- Promote \`noopLogger\` to \`@agentry/core\` to dedupe across testing + 2 adapter test files (depcruiser bars adapter→testing) — file when a 4th driver appears

## Closes

This is the entirety of Phase 4 work. After merge, epic #4 will be closed and Phase 5 (Docker compose & VPS deploy) becomes the next milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)