### PR TITLE
refactor(jobrunner): payload+handler-registry port for cross-process adapters

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -423,19 +423,46 @@ context propagation.
 ### 4.8 JobRunner — issue #25
 
 ```ts
+interface JobHandler<P> {
+  (payload: P): Promise<void>;
+}
+
+interface JobQueue<P> {
+  enqueue(opts: { key: string; payload: P }): Promise<void>;
+}
+
 interface JobRunner {
   /**
-   * Enqueue a job. Same `key` → serialized FIFO. Different keys → parallel.
-   * Resolves after the job is enqueued (NOT after it completes).
+   * Register a queue handler at composition time. Returns a typed enqueue
+   * handle. Calling `register` twice for the same queue throws.
    */
-  enqueue(opts: { key: string; job: () => Promise<void> }): Promise<void>;
+  register<P>(queue: string, handler: JobHandler<P>): JobQueue<P>;
+
+  /**
+   * Graceful shutdown: wait until this process's in-flight jobs complete.
+   * Cross-process adapters drain per-process — other workers' jobs are
+   * not awaited.
+   */
+  drain(): Promise<void>;
 }
 ```
+
+**Why payload + handler-registry (not closure-as-job)**: the closure shape locked
+us into a single-process model — a function reference and its captured
+dependencies cannot travel through a queue medium. Promoting to "register the
+handler at boot, publish data only" makes the same port satisfiable by pg-boss,
+BullMQ, SQS, Kafka — all of which serialize the payload through their own
+medium and dispatch to a pre-registered handler on the worker side.
 
 **Why per-key**: back-to-back messages in the same Slack thread arrive faster than
 agent runs complete. Without per-key serialization, two parallel `recordTurn`s and
 two parallel agent invocations race on the same session — interleaved or duplicated
 state results. Per-key serial guarantees ordered processing within a session.
+
+**Payload contract**: payloads must be JSON-roundtrip-safe (plain objects,
+arrays, primitives, `null`; `Date` is allowed and adapters MUST handle it).
+The in-memory adapter passes payloads by reference and does NOT enforce this;
+the pg-boss adapter (#28) will.
 
 **MVP adapter**: in-memory `Map<key, Promise>` chain. Single process.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once it leaves pre-1.0. Until then, every published change is breaking by default.
 
-## [Unreleased] — Phase 4
+## [Unreleased] — Phase 4 + early Phase 5
 
 ### Added
 - Extension guides for channel adapters, agent runners, embedding providers, and store adapters (`docs/extending/*`).
@@ -11,6 +11,7 @@ All notable changes are recorded here. Format follows [Keep a Changelog](https:/
 
 ### Changed
 - `docs/extending/configuration.md` answers the previously open question on adapter-specific secrets — centralized `SecretsSchema` in `runtime` is the chosen pattern; adapters take plain values via constructor.
+- **JobRunner port redesigned** for cross-process adapters (refs #28). Closure-as-job (`enqueue({ key, job })`) replaced with payload + handler-registry (`register(queue, handler)` returning a typed `JobQueue<P>` with `enqueue({ key, payload })`). `drain()` lifted from the in-memory adapter to the port itself. Same per-key FIFO semantics. Use-case factories now register their queue handler at construction (`HANDLE_INCOMING_QUEUE` exported from `@agentry/core`). The worker callback re-reads `Session` via `SessionStore.findByRef` instead of relying on a closure-captured snapshot — multi-process correctness, aligned with §4.9. Breaking change for any downstream `JobRunner` adapter; both in-memory copies in this repo are updated in lockstep.
 
 ## Phase 3 — MVP slice (2026-04 → 2026-05)
 

--- a/packages/adapter-jobrunner-memory/src/in-memory-job-runner.test.ts
+++ b/packages/adapter-jobrunner-memory/src/in-memory-job-runner.test.ts
@@ -33,22 +33,14 @@ describe('InMemoryJobRunner', () => {
     const gateA = deferred<void>();
     const gateB = deferred<void>();
 
-    await runner.enqueue({
-      key: 'session-1',
-      job: async () => {
-        order.push('a:start');
-        await gateA.promise;
-        order.push('a:end');
-      },
+    const queue = runner.register<{ id: string; gate: Deferred<void> }>('q', async (payload) => {
+      order.push(`${payload.id}:start`);
+      await payload.gate.promise;
+      order.push(`${payload.id}:end`);
     });
-    await runner.enqueue({
-      key: 'session-1',
-      job: async () => {
-        order.push('b:start');
-        await gateB.promise;
-        order.push('b:end');
-      },
-    });
+
+    await queue.enqueue({ key: 'session-1', payload: { id: 'a', gate: gateA } });
+    await queue.enqueue({ key: 'session-1', payload: { id: 'b', gate: gateB } });
 
     await settle();
     expect(order).toEqual(['a:start']);
@@ -68,22 +60,14 @@ describe('InMemoryJobRunner', () => {
     const gateA = deferred<void>();
     const gateB = deferred<void>();
 
-    await runner.enqueue({
-      key: 'session-1',
-      job: async () => {
-        order.push('a:start');
-        await gateA.promise;
-        order.push('a:end');
-      },
+    const queue = runner.register<{ id: string; gate: Deferred<void> }>('q', async (payload) => {
+      order.push(`${payload.id}:start`);
+      await payload.gate.promise;
+      order.push(`${payload.id}:end`);
     });
-    await runner.enqueue({
-      key: 'session-2',
-      job: async () => {
-        order.push('b:start');
-        await gateB.promise;
-        order.push('b:end');
-      },
-    });
+
+    await queue.enqueue({ key: 'session-1', payload: { id: 'a', gate: gateA } });
+    await queue.enqueue({ key: 'session-2', payload: { id: 'b', gate: gateB } });
 
     await settle();
     // Both started — different keys do not block each other.
@@ -103,18 +87,13 @@ describe('InMemoryJobRunner', () => {
     const runner = new InMemoryJobRunner({ onError });
     const order: string[] = [];
 
-    await runner.enqueue({
-      key: 'k',
-      job: async () => {
-        throw new Error('boom');
-      },
+    const queue = runner.register<{ throws: boolean }>('q', async (payload) => {
+      if (payload.throws) throw new Error('boom');
+      order.push('after-error');
     });
-    await runner.enqueue({
-      key: 'k',
-      job: async () => {
-        order.push('after-error');
-      },
-    });
+
+    await queue.enqueue({ key: 'k', payload: { throws: true } });
+    await queue.enqueue({ key: 'k', payload: { throws: false } });
 
     await runner.drain();
     expect(order).toEqual(['after-error']);
@@ -133,18 +112,13 @@ describe('InMemoryJobRunner', () => {
     });
     const order: string[] = [];
 
-    await runner.enqueue({
-      key: 'k',
-      job: async () => {
-        throw new Error('boom');
-      },
+    const queue = runner.register<{ throws: boolean }>('q', async (payload) => {
+      if (payload.throws) throw new Error('boom');
+      order.push('after');
     });
-    await runner.enqueue({
-      key: 'k',
-      job: async () => {
-        order.push('after');
-      },
-    });
+
+    await queue.enqueue({ key: 'k', payload: { throws: true } });
+    await queue.enqueue({ key: 'k', payload: { throws: false } });
 
     await runner.drain();
     expect(order).toEqual(['after']);
@@ -156,14 +130,13 @@ describe('InMemoryJobRunner', () => {
     let started = false;
     let finished = false;
 
-    const enqueuePromise = runner.enqueue({
-      key: 'k',
-      job: async () => {
-        started = true;
-        await gate.promise;
-        finished = true;
-      },
+    const queue = runner.register<null>('q', async () => {
+      started = true;
+      await gate.promise;
+      finished = true;
     });
+
+    const enqueuePromise = queue.enqueue({ key: 'k', payload: null });
 
     await enqueuePromise;
     // The job may have started its first microtask but cannot have finished.
@@ -185,20 +158,14 @@ describe('InMemoryJobRunner', () => {
     let aDone = false;
     let bDone = false;
 
-    await runner.enqueue({
-      key: 'a',
-      job: async () => {
-        await gateA.promise;
-        aDone = true;
-      },
+    const queue = runner.register<{ id: string; gate: Deferred<void> }>('q', async (payload) => {
+      await payload.gate.promise;
+      if (payload.id === 'a') aDone = true;
+      else bDone = true;
     });
-    await runner.enqueue({
-      key: 'b',
-      job: async () => {
-        await gateB.promise;
-        bDone = true;
-      },
-    });
+
+    await queue.enqueue({ key: 'a', payload: { id: 'a', gate: gateA } });
+    await queue.enqueue({ key: 'b', payload: { id: 'b', gate: gateB } });
 
     queueMicrotask(() => {
       gateA.resolve();
@@ -208,5 +175,27 @@ describe('InMemoryJobRunner', () => {
     await runner.drain();
     expect(aDone).toBe(true);
     expect(bDone).toBe(true);
+  });
+
+  it('register throws on duplicate queue name', () => {
+    const runner = new InMemoryJobRunner();
+    runner.register('q', async () => {});
+    expect(() => runner.register('q', async () => {})).toThrow(/already registered/);
+  });
+
+  it('routes different queues to their own handlers', async () => {
+    const runner = new InMemoryJobRunner();
+    const seen: string[] = [];
+    const qA = runner.register<{ v: string }>('a', async (p) => {
+      seen.push(`a:${p.v}`);
+    });
+    const qB = runner.register<{ v: string }>('b', async (p) => {
+      seen.push(`b:${p.v}`);
+    });
+    await qA.enqueue({ key: 'k', payload: { v: '1' } });
+    await qB.enqueue({ key: 'k', payload: { v: '2' } });
+    await runner.drain();
+    // FIFO on shared key — a's job before b's.
+    expect(seen).toEqual(['a:1', 'b:2']);
   });
 });

--- a/packages/adapter-jobrunner-memory/src/in-memory-job-runner.ts
+++ b/packages/adapter-jobrunner-memory/src/in-memory-job-runner.ts
@@ -1,4 +1,4 @@
-import type { JobRunner, JobRunnerEnqueueOptions } from '@agentry/core';
+import type { JobEnqueueOptions, JobHandler, JobQueue, JobRunner } from '@agentry/core';
 
 export interface InMemoryJobRunnerOptions {
   // Invoked once per job rejection. The chain continues regardless — a
@@ -7,21 +7,40 @@ export interface InMemoryJobRunnerOptions {
   readonly onError?: (err: unknown, key: string) => void;
 }
 
+interface QueueEntry {
+  readonly handler: JobHandler<unknown>;
+}
+
 // Single-process per-key serializer. Same key → FIFO chain; different keys
-// run independently. Swap to pg-boss / BullMQ when crossing process boundaries
-// (see ARCHITECTURE.md §4.8).
+// run independently. Swap to pg-boss / BullMQ when crossing process
+// boundaries (see ARCHITECTURE.md §4.8).
 export class InMemoryJobRunner implements JobRunner {
   private readonly chains = new Map<string, Promise<void>>();
+  private readonly queues = new Map<string, QueueEntry>();
 
   constructor(private readonly options: InMemoryJobRunnerOptions = {}) {}
 
-  async enqueue(opts: JobRunnerEnqueueOptions): Promise<void> {
-    const key = opts.key;
-    const job = opts.job;
+  register<P>(queue: string, handler: JobHandler<P>): JobQueue<P> {
+    if (this.queues.has(queue)) {
+      throw new Error(`JobRunner: queue '${queue}' is already registered`);
+    }
+    this.queues.set(queue, { handler: handler as JobHandler<unknown> });
+    return {
+      enqueue: (opts: JobEnqueueOptions<P>) => this.enqueueInternal(queue, opts),
+    };
+  }
+
+  private async enqueueInternal<P>(queue: string, opts: JobEnqueueOptions<P>): Promise<void> {
+    const entry = this.queues.get(queue);
+    if (!entry) {
+      throw new Error(`JobRunner: queue '${queue}' is not registered`);
+    }
+    const { key, payload } = opts;
+    const handler = entry.handler;
     const previous = this.chains.get(key) ?? Promise.resolve();
     const onError = this.options.onError;
     const next: Promise<void> = previous
-      .then(() => job())
+      .then(() => handler(payload))
       .catch((err: unknown) => {
         if (onError) {
           try {

--- a/packages/core/src/app/handle-incoming-message.ts
+++ b/packages/core/src/app/handle-incoming-message.ts
@@ -32,10 +32,25 @@ export type HandleIncomingMessage = (event: IncomingEvent) => Promise<void>;
 
 const DEFAULT_TOP_K = 5;
 
+// Queue name used by `makeHandleIncomingMessage` to register its job handler
+// with the `JobRunner`. Exported so cross-process worker processes (pg-boss,
+// BullMQ, ...) can target the same queue when wiring an alternative composition.
+export const HANDLE_INCOMING_QUEUE = 'handle-incoming';
+
 // Header for the optional channel-context block prepended to the agent
 // prompt. Kept as an exported constant so seed/agent-workdir/CLAUDE.md can
 // refer to it by name and stay in sync if it changes.
 export const CHANNEL_CONTEXT_HEADER = '[Channel context]';
+
+// Job payload travelling through the `JobRunner` queue. Identifiers + the
+// live event only — the use-case handler re-reads `Session` via
+// `findByRef` at job-execution time so a multi-process adapter sees fresh
+// metadata (same convention as ARCHITECTURE.md §4.9).
+export interface HandleIncomingPayload {
+  readonly sessionId: SessionId;
+  readonly tenantId: TenantId;
+  readonly event: IncomingEvent;
+}
 
 interface ProcessOneTurnArgs {
   readonly event: IncomingEvent;
@@ -49,6 +64,75 @@ interface ProcessOneTurnArgs {
 
 export function makeHandleIncomingMessage(deps: HandleIncomingMessageDeps): HandleIncomingMessage {
   const topK = deps.retrievalTopK ?? DEFAULT_TOP_K;
+
+  const queue = deps.jobRunner.register<HandleIncomingPayload>(
+    HANDLE_INCOMING_QUEUE,
+    async (payload) => {
+      const { event, sessionId, tenantId } = payload;
+      const log = deps.logger.child({
+        channelKind: event.channelKind,
+        idempotencyKey: event.idempotencyKey,
+        tenantId,
+        sessionId,
+      });
+
+      const policy = deps.sessionPolicies.get(event.channelKind);
+      if (!policy) {
+        // Unreachable in practice — publisher validates before enqueue —
+        // but explicit so a cross-process worker that lost the policy
+        // registration fails loudly rather than silently.
+        log.error({ channelKind: event.channelKind }, 'no session policy for channel kind');
+        throw new Error(`No SessionPolicy registered for channel kind: ${event.channelKind}`);
+      }
+
+      const firstTouch = deps.sessionFirstTouches?.get(event.channelKind);
+
+      // Re-read session metadata so multi-process workers see other
+      // workers' first-touch updates (ARCHITECTURE.md §4.9). For the
+      // in-memory adapter this is a cheap Map read. Null here means the
+      // session vanished between publisher (findOrCreate) and worker —
+      // an invariant violation, not a recoverable state. The id check
+      // catches a re-created-under-same-ref scenario where findByRef
+      // returns a different session than the publisher saw.
+      const session = await deps.sessionStore.findByRef(
+        event.channelKind,
+        policy.computeNativeRef(event),
+        tenantId,
+      );
+      if (session === null) {
+        throw new Error(
+          `Session ${sessionId} not found at job execution time (channelKind=${event.channelKind})`,
+        );
+      }
+      if (session.id !== sessionId) {
+        throw new Error(
+          `Session id drifted: publisher saw ${sessionId}, worker re-read ${session.id}`,
+        );
+      }
+
+      if (firstTouch !== undefined) {
+        let synthetics: readonly IncomingEvent[] = [];
+        try {
+          synthetics = await firstTouch.onFirstTouch({ session, event });
+        } catch (err) {
+          // Backfill failure must not drop the live event.
+          log.warn({ err }, 'session first-touch failed; proceeding with live event only');
+        }
+        for (const synth of synthetics) {
+          await processOneTurn({
+            event: synth,
+            sessionId,
+            tenantId,
+            log,
+            deps,
+            topK,
+            policy,
+          });
+        }
+      }
+      await processOneTurn({ event, sessionId, tenantId, log, deps, topK, policy });
+    },
+  );
 
   return async function handleIncomingMessage(event: IncomingEvent): Promise<void> {
     const baseLog = deps.logger.child({
@@ -67,41 +151,11 @@ export function makeHandleIncomingMessage(deps: HandleIncomingMessageDeps): Hand
     const tenantLog = baseLog.child({ tenantId, channelNativeRef: nativeRef });
 
     const session = await deps.sessionStore.findOrCreate(event.channelKind, nativeRef, tenantId);
-    const log = tenantLog.child({ sessionId: session.id });
-    log.info({}, 'session resolved; enqueueing turn');
+    tenantLog.child({ sessionId: session.id }).info({}, 'session resolved; enqueueing turn');
 
-    const firstTouch = deps.sessionFirstTouches?.get(event.channelKind);
-
-    await deps.jobRunner.enqueue({
+    await queue.enqueue({
       key: session.id,
-      // First-touch + live processing run inside the per-key FIFO chain
-      // (see InMemoryJobRunner). Mention 2 cannot start until mention 1
-      // resolves, so a single-process deployment never double-fetches
-      // history. Multi-process correctness relies on the impl re-reading
-      // session metadata via SessionStore.findByRef.
-      job: async () => {
-        if (firstTouch !== undefined) {
-          let synthetics: readonly IncomingEvent[] = [];
-          try {
-            synthetics = await firstTouch.onFirstTouch({ session, event });
-          } catch (err) {
-            // Backfill failure must not drop the live event.
-            log.warn({ err }, 'session first-touch failed; proceeding with live event only');
-          }
-          for (const synth of synthetics) {
-            await processOneTurn({
-              event: synth,
-              sessionId: session.id,
-              tenantId,
-              log,
-              deps,
-              topK,
-              policy,
-            });
-          }
-        }
-        await processOneTurn({ event, sessionId: session.id, tenantId, log, deps, topK, policy });
-      },
+      payload: { sessionId: session.id, tenantId, event },
     });
   };
 }

--- a/packages/core/src/app/index.ts
+++ b/packages/core/src/app/index.ts
@@ -1,5 +1,10 @@
 export type {
   HandleIncomingMessage,
   HandleIncomingMessageDeps,
+  HandleIncomingPayload,
 } from './handle-incoming-message.js';
-export { CHANNEL_CONTEXT_HEADER, makeHandleIncomingMessage } from './handle-incoming-message.js';
+export {
+  CHANNEL_CONTEXT_HEADER,
+  HANDLE_INCOMING_QUEUE,
+  makeHandleIncomingMessage,
+} from './handle-incoming-message.js';

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -8,8 +8,10 @@ export type {
 export type { EmbeddingProvider } from './embedding-provider.js';
 export type { InboundChannel } from './inbound-channel.js';
 export type {
+  JobEnqueueOptions,
+  JobHandler,
+  JobQueue,
   JobRunner,
-  JobRunnerEnqueueOptions,
 } from './job-runner.js';
 export type { KnowledgeStore } from './knowledge-store.js';
 export type { Logger } from './logger.js';

--- a/packages/core/src/ports/job-runner.ts
+++ b/packages/core/src/ports/job-runner.ts
@@ -1,11 +1,43 @@
-export interface JobRunnerEnqueueOptions {
-  readonly key: string;
-  readonly job: () => Promise<void>;
+// Per-key serialization primitive. Same `key` runs FIFO, different keys run
+// in parallel. `enqueue` resolves once the job is queued, NOT after it
+// completes — back-pressure is not part of this contract.
+//
+// Payload + handler-registry shape (vs. closure-as-job) lets a distributed
+// adapter (pg-boss, BullMQ, SQS, ...) wire the same port: payload travels
+// through the queue medium as data; the handler is registered at boot on
+// every process that runs the queue. ARCHITECTURE.md §4.8 covers when to
+// swap from in-memory to a cross-process adapter.
+//
+// Payload contract: must be JSON-roundtrip-safe (plain objects, arrays,
+// numbers, strings, booleans, null; `Date` is allowed and adapters MUST
+// handle it explicitly — pg-boss serializes via ISO string). In-memory
+// adapter passes payload by reference and does not enforce this; the
+// pg-boss adapter does.
+
+export interface JobHandler<P> {
+  (payload: P): Promise<void>;
 }
 
-// Per-key serialization primitive: same `key` runs FIFO, different keys
-// run in parallel. `enqueue` resolves once the job is queued, NOT after it
-// completes — back-pressure is not part of this contract.
+export interface JobEnqueueOptions<P> {
+  readonly key: string;
+  readonly payload: P;
+}
+
+// Typed enqueue handle returned by `JobRunner.register`. The typing prevents
+// publishing to a queue with the wrong payload shape and removes the need to
+// thread queue names through call sites.
+export interface JobQueue<P> {
+  enqueue(opts: JobEnqueueOptions<P>): Promise<void>;
+}
+
 export interface JobRunner {
-  enqueue(opts: JobRunnerEnqueueOptions): Promise<void>;
+  // Register a queue handler. Must be called at composition time, before any
+  // `enqueue` for that queue. Calling `register` twice for the same queue
+  // throws — duplicate registration indicates a boot-time misconfiguration.
+  register<P>(queue: string, handler: JobHandler<P>): JobQueue<P>;
+
+  // Graceful shutdown: wait until this process's in-flight jobs complete.
+  // Cross-process adapters (pg-boss, BullMQ) do NOT wait for jobs running on
+  // other workers — drain is per-process by design.
+  drain(): Promise<void>;
 }

--- a/packages/testing/src/app/handle-incoming-message.test.ts
+++ b/packages/testing/src/app/handle-incoming-message.test.ts
@@ -277,4 +277,40 @@ describe('makeHandleIncomingMessage', () => {
     expect((harness.errors[0]?.err as Error).message).toMatch(/OutboundChannel/);
     expect(harness.errors[0]?.key).toBe(session.id);
   });
+
+  // Cross-process invariant guards added by the JobRunner port redesign
+  // (#28). The publisher creates the session via findOrCreate; the worker
+  // re-reads it via findByRef. Two failure shapes the in-memory adapter
+  // never produces but pg-boss can:
+  //
+  //   (a) Session disappeared between publisher and worker → findByRef null.
+  //   (b) Session re-created under the same (kind, ref, tenant) with a new
+  //       id → findByRef returns a session whose id differs from the
+  //       publisher's `session.id`.
+  //
+  // Both are invariant violations: the handler throws and the JobRunner's
+  // onError surfaces them.
+  it('throws when findByRef returns null at worker time (session vanished)', async () => {
+    // Swap findByRef before handle(): publisher uses findOrCreate which is
+    // unaffected; the worker's re-read sees null and trips the guard.
+    harness.sessionStore.findByRef = async () => null;
+    await harness.handle(makeEvent());
+    await harness.jobRunner.drain();
+
+    expect(harness.errors).toHaveLength(1);
+    expect((harness.errors[0]?.err as Error).message).toMatch(/not found at job execution time/);
+  });
+
+  it('throws when findByRef returns a session with a drifted id', async () => {
+    const original = await harness.sessionStore.findOrCreate('test', 'thread-1', 'tenant-1');
+    harness.sessionStore.findByRef = async () => ({
+      ...original,
+      id: 'sess-drifted' as typeof original.id,
+    });
+    await harness.handle(makeEvent());
+    await harness.jobRunner.drain();
+
+    expect(harness.errors).toHaveLength(1);
+    expect((harness.errors[0]?.err as Error).message).toMatch(/Session id drifted/);
+  });
 });

--- a/packages/testing/src/job-runner/in-memory-job-runner.test.ts
+++ b/packages/testing/src/job-runner/in-memory-job-runner.test.ts
@@ -29,21 +29,14 @@ describe('testing.InMemoryJobRunner', () => {
     const order: string[] = [];
     const gateA = deferred<void>();
 
-    await runner.enqueue({
-      key: 'k',
-      job: async () => {
-        order.push('a:start');
-        await gateA.promise;
-        order.push('a:end');
-      },
+    const queue = runner.register<{ id: string; gate?: Deferred<void> }>('q', async (payload) => {
+      order.push(`${payload.id}:start`);
+      if (payload.gate) await payload.gate.promise;
+      order.push(`${payload.id}:end`);
     });
-    await runner.enqueue({
-      key: 'k',
-      job: async () => {
-        order.push('b:start');
-        order.push('b:end');
-      },
-    });
+
+    await queue.enqueue({ key: 'k', payload: { id: 'a', gate: gateA } });
+    await queue.enqueue({ key: 'k', payload: { id: 'b' } });
 
     await settle();
     expect(order).toEqual(['a:start']);
@@ -58,19 +51,13 @@ describe('testing.InMemoryJobRunner', () => {
     const order: string[] = [];
     const gateA = deferred<void>();
 
-    await runner.enqueue({
-      key: 'a',
-      job: async () => {
-        order.push('a:start');
-        await gateA.promise;
-      },
+    const queue = runner.register<{ id: string; gate?: Deferred<void> }>('q', async (payload) => {
+      order.push(`${payload.id}:start`);
+      if (payload.gate) await payload.gate.promise;
     });
-    await runner.enqueue({
-      key: 'b',
-      job: async () => {
-        order.push('b:start');
-      },
-    });
+
+    await queue.enqueue({ key: 'a', payload: { id: 'a', gate: gateA } });
+    await queue.enqueue({ key: 'b', payload: { id: 'b' } });
 
     await settle();
     expect(order).toEqual(['a:start', 'b:start']);
@@ -83,18 +70,13 @@ describe('testing.InMemoryJobRunner', () => {
     const runner = new InMemoryJobRunner({ onError });
     const order: string[] = [];
 
-    await runner.enqueue({
-      key: 'k',
-      job: async () => {
-        throw new Error('boom');
-      },
+    const queue = runner.register<{ throws: boolean }>('q', async (payload) => {
+      if (payload.throws) throw new Error('boom');
+      order.push('after');
     });
-    await runner.enqueue({
-      key: 'k',
-      job: async () => {
-        order.push('after');
-      },
-    });
+
+    await queue.enqueue({ key: 'k', payload: { throws: true } });
+    await queue.enqueue({ key: 'k', payload: { throws: false } });
 
     await runner.drain();
     expect(order).toEqual(['after']);

--- a/packages/testing/src/job-runner/in-memory-job-runner.ts
+++ b/packages/testing/src/job-runner/in-memory-job-runner.ts
@@ -1,26 +1,45 @@
-import type { JobRunner, JobRunnerEnqueueOptions } from '@agentry/core';
+import type { JobEnqueueOptions, JobHandler, JobQueue, JobRunner } from '@agentry/core';
 
 // Test-side mirror of `@agentry/adapter-jobrunner-memory`. Duplicated because
 // dependency-cruiser blocks `packages/testing` from importing adapter packages
-// (`testing-only-imports-core`). Behaviour is intentionally identical: same key
-// runs FIFO, different keys run independently, job failures route to onError
-// instead of poisoning the chain.
+// (`testing-only-imports-core`). Behaviour is intentionally identical: same
+// key runs FIFO, different keys run independently, job failures route to
+// onError instead of poisoning the chain. Keep both copies in lockstep.
 export interface InMemoryJobRunnerOptions {
   readonly onError?: (err: unknown, key: string) => void;
 }
 
+interface QueueEntry {
+  readonly handler: JobHandler<unknown>;
+}
+
 export class InMemoryJobRunner implements JobRunner {
   private readonly chains = new Map<string, Promise<void>>();
+  private readonly queues = new Map<string, QueueEntry>();
 
   constructor(private readonly options: InMemoryJobRunnerOptions = {}) {}
 
-  async enqueue(opts: JobRunnerEnqueueOptions): Promise<void> {
-    const key = opts.key;
-    const job = opts.job;
+  register<P>(queue: string, handler: JobHandler<P>): JobQueue<P> {
+    if (this.queues.has(queue)) {
+      throw new Error(`JobRunner: queue '${queue}' is already registered`);
+    }
+    this.queues.set(queue, { handler: handler as JobHandler<unknown> });
+    return {
+      enqueue: (opts: JobEnqueueOptions<P>) => this.enqueueInternal(queue, opts),
+    };
+  }
+
+  private async enqueueInternal<P>(queue: string, opts: JobEnqueueOptions<P>): Promise<void> {
+    const entry = this.queues.get(queue);
+    if (!entry) {
+      throw new Error(`JobRunner: queue '${queue}' is not registered`);
+    }
+    const { key, payload } = opts;
+    const handler = entry.handler;
     const previous = this.chains.get(key) ?? Promise.resolve();
     const onError = this.options.onError;
     const next: Promise<void> = previous
-      .then(() => job())
+      .then(() => handler(payload))
       .catch((err: unknown) => {
         if (onError) {
           try {


### PR DESCRIPTION
## Summary

First PR in the #28 series — redesigns the `JobRunner` port so the same contract can be satisfied by a cross-process adapter (pg-boss, BullMQ, …). The closure-as-job shape (`enqueue({ key, job })`) was single-process-only because functions and their captured dependencies cannot travel through a queue medium. This PR ships the port shape; the **pg-boss adapter follows in a separate PR** (which will actually close #28).

- New shape: `register<P>(queue, handler) → JobQueue<P>` with payload-only enqueue. Payload travels as data; handlers are registered at boot on every process that runs the queue.
- `drain()` lifted from `InMemoryJobRunner` to the port. Per-process drain semantics documented (other workers' jobs are not awaited).
- `makeHandleIncomingMessage` registers `HANDLE_INCOMING_QUEUE` internally; `HandleIncomingPayload = { sessionId, tenantId, event }` carries identifiers + the live event only. Worker re-reads `Session` via `SessionStore.findByRef` (same pattern as §4.9 `SessionFirstTouch`).
- Cross-process invariant guards added on the worker side: throws when the session vanished between publisher and worker, or when the re-read returns a session with a drifted id. Both surface via `JobRunner.onError` and are covered by new unit tests.
- ARCHITECTURE.md §4.8 contract synced; CHANGELOG Unreleased entry added.

## Trade-offs considered

- **Composition alternative** — compose could own `register` and pass a typed `JobQueue<HandleIncomingPayload>` to `makeHandleIncomingMessage`. Cleaner separation but splits handler body across layers. Kept register-internal so the handler and its queue registration sit in one file.
- **Worker-side `findByRef` adds one DB roundtrip per inbound message under pg-boss.** Deliberate — multi-process correctness requires reading fresh metadata. In-memory this is a free Map read.
- **`onError` stays as an adapter constructor option** (not on the port). Each adapter expresses its own failure-surfacing affordance; the port stays minimal.
- **JSON-roundtrip enforcement deferred to the pg-boss PR.** This PR documents the payload contract in JSDoc + ARCHITECTURE.md but does not enforce it in the in-memory adapter (which passes by reference).
- **Two `InMemoryJobRunner` copies** (adapter + testing-mirror) updated in lockstep. dependency-cruiser blocks cross-import; the duplication is structurally enforced.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm lint\` — green (Biome: 7 infos, no errors)
- [x] \`pnpm test\` — 227 passing, 29 skipped (+2 new guard tests, −1 deleted meaningless test)
- [x] \`pnpm depcheck\` — no dependency violations

Refs #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)